### PR TITLE
Add sidebar store and sliding NodePalette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,20 +3,21 @@ import { WorkflowEditor } from './components/WorkflowEditor';
 import { NodePalette } from './components/NodePalette';
 import { NodeConfigPanel } from './components/NodeConfigPanel';
 import { Toolbar } from './components/Toolbar';
+import { useWorkflowStore } from './store/workflowStore';
 import "./App.css"
 
 function App() {
+  const sidebarOpen = useWorkflowStore((state) => state.sidebarOpen);
+
   return (
-      <div className="h-screen flex flex-col">
-        <Toolbar />
-        <div className="flex-1 flex">
-          <NodePalette />
-          <div className="flex-1 relative">
-            <WorkflowEditor />
-          </div>
-          {/* <NodeConfigPanel /> */}
-        </div>
+    <div className="h-screen flex flex-col">
+      <Toolbar />
+      <div className="flex-1 relative">
+        <WorkflowEditor />
+        {sidebarOpen && <NodePalette />}
+        {/* <NodeConfigPanel /> */}
       </div>
+    </div>
   );
 }
 

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -1,4 +1,5 @@
 import type { NodeType } from '../types/workflow';
+import { useWorkflowStore } from '../store/workflowStore';
 
 interface NodeTypeItem {
   type: NodeType;
@@ -51,8 +52,20 @@ function DraggableNode({ nodeType }: { nodeType: NodeTypeItem }) {
 }
 
 export function NodePalette() {
+  const sidebarOpen = useWorkflowStore((state) => state.sidebarOpen);
+  const closeSidebar = useWorkflowStore((state) => state.closeSidebar);
+
   return (
-    <div className="w-64 h-full bg-white border-r p-4 overflow-y-auto">
+    <div
+      className={`fixed top-14 bottom-0 left-0 w-64 bg-white border-r p-4 overflow-y-auto transform transition-transform duration-300 z-10 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
+    >
+      <button
+        onClick={closeSidebar}
+        className="absolute top-2 right-2 text-gray-500"
+        aria-label="Close sidebar"
+      >
+        ×
+      </button>
       <h2 className="text-lg font-semibold mb-4">Nodes</h2>
       <div className="space-y-2">
         {nodeTypes.map((nodeType) => (
@@ -61,4 +74,4 @@ export function NodePalette() {
       </div>
     </div>
   );
-} 
+}

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -7,6 +7,7 @@ const initialState = {
   selectedNode: null,
   undoStack: [],
   redoStack: [],
+  sidebarOpen: false,
 };
 
 export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
@@ -77,4 +78,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   clearWorkflow: () => set(initialState),
-})); 
+
+  openSidebar: () => set({ sidebarOpen: true }),
+  closeSidebar: () => set({ sidebarOpen: false }),
+}));

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -21,6 +21,7 @@ export interface WorkflowState {
   selectedNode: string | null;
   undoStack: Array<{ nodes: WorkflowNode[]; edges: WorkflowEdge[] }>;
   redoStack: Array<{ nodes: WorkflowNode[]; edges: WorkflowEdge[] }>;
+  sidebarOpen: boolean;
 }
 
 export interface WorkflowStore extends WorkflowState {
@@ -35,4 +36,6 @@ export interface WorkflowStore extends WorkflowState {
   undo: () => void;
   redo: () => void;
   clearWorkflow: () => void;
-} 
+  openSidebar: () => void;
+  closeSidebar: () => void;
+}


### PR DESCRIPTION
## Summary
- manage sidebarOpen state in the workflow store
- show/hide `<NodePalette />` when sidebar is opened
- slide palette in/out from the left

## Testing
- `npx tsc -p tsconfig.json`
- `yarn lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847f0346f708320a7c5ec51261460f0