### PR TITLE
Add global add button for workflow

### DIFF
--- a/src/components/GlobalAddButton.tsx
+++ b/src/components/GlobalAddButton.tsx
@@ -1,0 +1,17 @@
+import { useWorkflowStore } from '../store/workflowStore';
+
+export function GlobalAddButton() {
+  const openSidebar = useWorkflowStore(state => state.openSidebar);
+
+  return (
+    <button
+      onClick={openSidebar}
+      className="absolute top-4 right-4 z-10 p-2 rounded-full bg-blue-500 text-white shadow"
+      aria-label="Add node"
+    >
+      +
+    </button>
+  );
+}
+
+export default GlobalAddButton;

--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -12,6 +12,7 @@ import 'reactflow/dist/style.css';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { WorkflowNode, WorkflowEdge, WorkflowNodeData, NodeType } from '../types/workflow';
 import BaseNode from './nodes/BaseNode';
+import GlobalAddButton from './GlobalAddButton';
 
 const nodeTypes = {
   httpRequest: BaseNode,
@@ -92,7 +93,7 @@ export function WorkflowEditor() {
   );
 
   return (
-    <div className="w-full h-full" ref={reactFlowWrapper}>
+    <div className="w-full h-full relative" ref={reactFlowWrapper}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -110,6 +111,7 @@ export function WorkflowEditor() {
         <Controls />
         <MiniMap />
       </ReactFlow>
+      <GlobalAddButton />
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- create `GlobalAddButton` component
- overlay the new add button on the WorkflowEditor canvas
- clicking the button triggers `openSidebar()` to open the node palette

## Testing
- `yarn lint` *(fails: Cannot find package '@eslint/js' and other lint errors)*
- `yarn build` *(fails: TypeScript errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6847f2e9eda083209ade0db49dfd64aa