### PR TITLE
Implement dummy connection start UI

### DIFF
--- a/src/components/nodes/BaseNode.tsx
+++ b/src/components/nodes/BaseNode.tsx
@@ -8,6 +8,7 @@ import { FiGlobe, FiClock, FiSliders, FiGitBranch, FiLink } from 'react-icons/fi
 function BaseNode({ id, data }: NodeProps<WorkflowNodeData>) {
   const openSidebar = useWorkflowStore((state) => state.openSidebar);
   const setPendingConnection = useWorkflowStore((state) => state.setPendingConnection);
+  const edges = useWorkflowStore((state) => state.edges);
 
   const IconMap = {
     httpRequest: FiGlobe,
@@ -19,6 +20,8 @@ function BaseNode({ id, data }: NodeProps<WorkflowNodeData>) {
 
   const Icon = IconMap[data.type];
 
+  const hasOutgoing = edges.some((edge) => edge.source === id);
+
   const onAdd = (e: React.MouseEvent) => {
     e.stopPropagation();
     setPendingConnection({ source: id, sourceHandle: null });
@@ -26,29 +29,37 @@ function BaseNode({ id, data }: NodeProps<WorkflowNodeData>) {
   };
 
   return (
-    <div className="relative bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md px-3 py-2 shadow">
-      <Handle
-        type="target"
-        position={Position.Left}
-        className="w-2 h-4 !rounded-none" />
-      <div className="flex flex-col items-center">
-        <Icon className="w-6 h-6 text-primary-500" />
-        <div className="text-xs mt-1 text-gray-800 dark:text-gray-100">{data.label}</div>
-      </div>
-      <div className="absolute -right-2 top-1/2 -translate-y-1/2 flex items-center">
+    <div className="relative flex flex-col items-center">
+      <div className="relative bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md px-3 py-2 shadow">
         <Handle
-          type="source"
-          position={Position.Right}
-          className="w-3 h-3"
-          onDoubleClick={onAdd}
+          type="target"
+          position={Position.Left}
+          className="w-2 h-4 !rounded-none"
         />
-        <button
-          onClick={onAdd}
-          className="ml-1 w-4 h-4 flex items-center justify-center text-xs bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-100 rounded"
-          aria-label="Add node"
-        >
-          +
-        </button>
+        <Icon className="w-6 h-6 text-primary-500" />
+        <div className="absolute -right-2 top-1/2 -translate-y-1/2">
+          <Handle
+            type="source"
+            position={Position.Right}
+            className="w-3 h-3"
+            onDoubleClick={onAdd}
+          />
+        </div>
+        {!hasOutgoing && (
+          <div className="absolute -right-8 top-1/2 -translate-y-1/2 flex items-center">
+            <div className="w-4 h-px bg-gray-400 dark:bg-gray-600" />
+            <button
+              onClick={onAdd}
+              className="ml-1 w-4 h-4 flex items-center justify-center text-xs bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-100 rounded"
+              aria-label="Add node"
+            >
+              +
+            </button>
+          </div>
+        )}
+      </div>
+      <div className="text-xs mt-1 text-gray-800 dark:text-gray-100 text-center">
+        {data.label}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render node labels under the node block
- remove add button from node body
- show a short "dummy" edge with plus button for nodes without outputs

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_684807e07fb08320820463ac0767cfb7