### PR TITLE
Fix plus handle behavior

### DIFF
--- a/src/components/nodes/StyledNode.tsx
+++ b/src/components/nodes/StyledNode.tsx
@@ -2,13 +2,26 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { WorkflowNodeData } from '../../types/workflow';
-import { FiGlobe, FiClock, FiSliders, FiGitBranch, FiLink } from 'react-icons/fi';
+import {
+  FiGlobe,
+  FiClock,
+  FiSliders,
+  FiGitBranch,
+  FiLink,
+  FiPlus,
+} from 'react-icons/fi';
+import { useWorkflowStore } from '../../store/workflowStore';
 
 interface StyledNodeProps extends NodeProps<WorkflowNodeData> {
   darkMode?: boolean;
 }
 
-function StyledNode({ data, darkMode = false }: StyledNodeProps) {
+function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
+  // Access edges from global workflow store to determine if this node already has
+  // an outgoing connection. The component re-renders automatically when edges
+  // change, so the icon visibility updates in realtime.
+  const edges = useWorkflowStore((state) => state.edges);
+  const hasOutgoing = edges.some((e) => e.source === id);
   const colors = {
     background: darkMode ? '#1E2235' : '#FFFFFF',
     border: darkMode ? 'rgba(255,255,255,0.2)' : '#C1C1C1',
@@ -70,35 +83,24 @@ function StyledNode({ data, darkMode = false }: StyledNodeProps) {
         id="out"
         position={Position.Right}
         style={{
-          width: 10,
-          height: 10,
+          width: 16,
+          height: 16,
           borderRadius: '50%',
           border: `2px solid ${colors.border}`,
           background: colors.background,
-        }}
-      />
-      <Handle
-        type="source"
-        id="add"
-        position={Position.Right}
-        style={{
-          width: 24,
-          height: 24,
-          borderRadius: 4,
-          border: `2px solid ${colors.border}`,
-          background: colors.background,
-          right: -32,
+          right: -8,
           top: '50%',
           transform: 'translate(50%, -50%)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          color: colors.text,
-          fontSize: 16,
-          fontWeight: 'bold',
         }}
       >
-        <span style={{ pointerEvents: 'none' }}>+</span>
+        {/* The plus icon is rendered inside the same handle and hidden once an
+            outgoing connection exists. */}
+        {!hasOutgoing && (
+          <FiPlus style={{ width: 10, height: 10, pointerEvents: 'none', color: colors.text }} />
+        )}
       </Handle>
     </div>
   );


### PR DESCRIPTION
## Summary
- tweak StyledNode: include plus icon inside single source handle
- hide plus icon when node has outgoing edge

## Testing
- `yarn lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68491616fd2483208c6f2c1f01d67aae