### PR TITLE
Add global dark mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,18 @@ import { WorkflowEditor } from './components/WorkflowEditor';
 import { NodePalette } from './components/NodePalette';
 import { Toolbar } from './components/Toolbar';
 import { useWorkflowStore } from './store/workflowStore';
+import { useThemeStore } from './store/themeStore';
+import { useEffect } from 'react';
 import "./App.css"
 
 function App() {
   const sidebarOpen = useWorkflowStore((state) => state.sidebarOpen);
+  const theme = useThemeStore((state) => state.theme);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
 
   return (
     <div className="h-screen flex flex-col">

--- a/src/components/GlobalAddButton.tsx
+++ b/src/components/GlobalAddButton.tsx
@@ -6,7 +6,7 @@ export function GlobalAddButton() {
   return (
     <button
       onClick={openSidebar}
-      className="absolute top-4 right-4 z-10 p-2 rounded-full bg-blue-500 text-white shadow"
+      className="btn-icon absolute top-4 right-4 z-10 p-2 rounded-full bg-blue-500 text-white shadow hover:bg-blue-600"
       aria-label="Add node"
     >
       +

--- a/src/components/GlobalAddButton.tsx
+++ b/src/components/GlobalAddButton.tsx
@@ -1,13 +1,13 @@
-import { useWorkflowStore } from '../store/workflowStore';
+import { useWorkflowStore } from "../store/workflowStore";
 
 export function GlobalAddButton() {
-  const openSidebar = useWorkflowStore(state => state.openSidebar);
+  const openSidebar = useWorkflowStore((state) => state.openSidebar);
 
   return (
     <button
       onClick={openSidebar}
-      className="btn-icon absolute top-4 right-4 z-10 p-2 rounded-full bg-blue-500 text-white shadow hover:bg-blue-600"
       aria-label="Add node"
+      className="btn-icon absolute top-4 right-4 border-2 bg-transparent hover:bg-blue-50dark:border-white dark:text-white dark:hover:bg-white/10"
     >
       +
     </button>

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -84,11 +84,11 @@ export function NodePalette() {
 
   return (
     <div
-      className={`fixed top-14 bottom-0 left-0 w-64 bg-white border-r p-4 overflow-y-auto transform transition-transform duration-300 z-10 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
+      className={`fixed top-14 bottom-0 left-0 w-64 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-4 overflow-y-auto transform transition-transform duration-300 z-10 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
     >
       <button
         onClick={closeSidebar}
-        className="absolute top-2 right-2 text-gray-500"
+        className="btn-icon absolute top-2 right-2"
         aria-label="Close sidebar"
       >
         ×

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,8 +1,12 @@
 import { useCallback } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
+import { useThemeStore } from '../store/themeStore';
+import { FiSun, FiMoon } from 'react-icons/fi';
 
 export function Toolbar() {
   const { nodes, edges, clearWorkflow } = useWorkflowStore();
+  const toggleTheme = useThemeStore((state) => state.toggleTheme);
+  const theme = useThemeStore((state) => state.theme);
 
   const handleNewWorkflow = useCallback(() => {
     if (window.confirm('Are you sure you want to create a new workflow? All unsaved changes will be lost.')) {
@@ -55,7 +59,7 @@ export function Toolbar() {
   }, []);
 
   return (
-    <div className="h-14 bg-white border-b px-4 flex items-center justify-between">
+    <div className="h-14 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 flex items-center justify-between">
       <div className="flex items-center space-x-2">
         <button
           onClick={handleNewWorkflow}
@@ -75,7 +79,6 @@ export function Toolbar() {
         >
           Load
         </button>
-        <button className="bg-red-500 text-white px-4 py-2 rounded">Test Tailwind</button>
       </div>
       <div className="flex items-center space-x-2">
         <button
@@ -84,7 +87,10 @@ export function Toolbar() {
         >
           Run
         </button>
+        <button onClick={toggleTheme} className="btn btn-secondary">
+          {theme === 'dark' ? <FiSun /> : <FiMoon />}
+        </button>
       </div>
     </div>
   );
-} 
+}

--- a/src/components/edges/ButtonEdge.tsx
+++ b/src/components/edges/ButtonEdge.tsx
@@ -71,20 +71,13 @@ export function ButtonEdge({
               position: "absolute",
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
             }}
-            className="flex items-center gap-0.5 bg-background"
+            className="flex items-center gap-0.5"
           >
             <button
               onClick={onAdd}
               aria-label="Add node"
               title="Add node"
-              style={{
-                border: "2px solid rgba(255,255,255,0.2)",
-                borderRadius: 4,
-                padding: 2,
-                background: "#1E2235",
-                color: "#FFFFFF",
-                cursor: "pointer",
-              }}
+              className="btn-icon bg-gray-800 border border-white/20 text-white"
             >
               <FiPlus size={5} />
             </button>
@@ -94,15 +87,7 @@ export function ButtonEdge({
               onClick={onDelete}
               aria-label="Delete edge"
               title="Delete edge"
-              className=" flex items-center justify-center "
-              style={{
-                border: "2px solid rgba(255,255,255,0.2)",
-                borderRadius: 4,
-                padding: 2,
-                background: "#1E2235",
-                color: "#FFFFFF",
-                cursor: "pointer",
-              }}
+              className="btn-icon bg-gray-800 border border-white/20 text-white flex items-center justify-center"
             >
               <FiTrash2 size={5} />
             </button>

--- a/src/components/edges/ButtonEdge.tsx
+++ b/src/components/edges/ButtonEdge.tsx
@@ -25,6 +25,9 @@ export function ButtonEdge({
     targetY,
     targetPosition,
   });
+
+  const theme = localStorage.getItem("theme");
+
   const [hovered, setHovered] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -71,13 +74,23 @@ export function ButtonEdge({
               position: "absolute",
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
             }}
-            className="flex items-center gap-0.5"
+            className="flex items-center gap-0.5 bg-background cursor-pointer"
           >
             <button
               onClick={onAdd}
               aria-label="Add node"
               title="Add node"
-              className="btn-icon bg-gray-800 border border-white/20 text-white"
+              style={{
+                borderRadius: 4,
+                padding: 2,
+                border:
+                  theme === "dark"
+                    ? "2px solid rgba(255,255,255,0.2)"
+                    : "2px solid #ccc",
+                background: theme === "dark" ? "#1E2235" : "#ffffff",
+                color: theme === "dark" ? "#ffffff" : "#333333",
+                cursor: "pointer",
+              }}
             >
               <FiPlus size={5} />
             </button>
@@ -87,7 +100,18 @@ export function ButtonEdge({
               onClick={onDelete}
               aria-label="Delete edge"
               title="Delete edge"
-              className="btn-icon bg-gray-800 border border-white/20 text-white flex items-center justify-center"
+              className="cursor-pointer"
+              style={{
+                borderRadius: 4,
+                padding: 2,
+                border:
+                  theme === "dark"
+                    ? "2px solid rgba(255,255,255,0.2)"
+                    : "2px solid #ccc",
+                background: theme === "dark" ? "#1E2235" : "#ffffff",
+                color: theme === "dark" ? "#ffffff" : "#333333",
+                cursor: "pointer",
+              }}
             >
               <FiTrash2 size={5} />
             </button>

--- a/src/components/edges/EdgeControls.tsx
+++ b/src/components/edges/EdgeControls.tsx
@@ -68,10 +68,10 @@ export default function EdgeControls({
             requiredExtensions="http://www.w3.org/1999/xhtml"
           >
             <div className="flex gap-1 bg-white dark:bg-gray-800 rounded shadow px-1">
-              <button onClick={onAdd} className="text-xs">
+              <button onClick={onAdd} className="btn-icon text-xs p-0.5" aria-label="Add edge">
                 +
               </button>
-              <button onClick={onDelete} className="text-xs">
+              <button onClick={onDelete} className="btn-icon text-xs p-0.5" aria-label="Delete edge">
                 ×
               </button>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,69 +1,23 @@
 @import "tailwindcss";
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+html, body, #root {
+  height: 100%;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+@layer components {
+  .btn {
+    @apply inline-flex items-center justify-center px-3 py-1.5 rounded-md text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2;
   }
-  a:hover {
-    color: #747bff;
+
+  .btn-primary {
+    @apply btn bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-500;
   }
-  button {
-    background-color: #f9f9f9;
+
+  .btn-secondary {
+    @apply btn bg-gray-100 text-gray-900 hover:bg-gray-200 focus-visible:ring-gray-400 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600;
+  }
+
+  .btn-icon {
+    @apply inline-flex items-center justify-center p-1 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-400;
   }
 }

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeStore {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const getInitialTheme = (): Theme => {
+  if (typeof localStorage !== 'undefined') {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored;
+  }
+  if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+  return 'light';
+};
+
+export const useThemeStore = create<ThemeStore>((set) => ({
+  theme: getInitialTheme(),
+  toggleTheme: () =>
+    set((state) => ({ theme: state.theme === 'dark' ? 'light' : 'dark' })),
+  setTheme: (theme) => set({ theme }),
+}));

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from 'tailwindcss'
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- enable `class`-based dark mode with a Tailwind config
- keep CSS minimal and rely on Tailwind
- track theme preference with a zustand store
- update App to apply theme class on the document
- expose a light/dark toggle button in the toolbar
- define global button component classes and apply them across the UI
- refine toolbar and sidebar styling for dark mode

## Testing
- `yarn lint` *(fails: Cannot find package '@eslint/js')*
- `yarn build` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6849545162a483208bb5183c3f37e60d