### PR TITLE
Implement webhook node and settings modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "reactflow": "^11.11.4",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  type Node,
+  type Edge,
+  type Connection,
+  type NodeChange,
+  type EdgeChange,
+  type NodeAddChange,
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import WebhookNode, { WebhookNodeData } from './nodes/WebhookNode';
+import WebhookSettingsModal from './WebhookSettingsModal';
+
+const nodeTypes = {
+  webhook: WebhookNode,
+};
+
+export default function FlowCanvas() {
+  const [nodes, setNodes] = useState<Node<WebhookNodeData>[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const baseTestUrl = 'https://your-app.com/webhook-test/';
+  const baseProdUrl = 'https://your-app.com/webhook/';
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes((nds) => {
+      const updated = applyNodeChanges(changes, nds);
+      changes.forEach((c) => {
+        if (c.type === 'add') {
+          const item = (c as NodeAddChange<WebhookNodeData>).item;
+          if (item?.type === 'webhook') {
+            setEditingId(item.id);
+          }
+        }
+      });
+      return updated;
+    });
+  }, []);
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => setEdges((eds) => applyEdgeChanges(changes, eds)),
+    []
+  );
+
+  const onConnect = useCallback(
+    (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
+    []
+  );
+
+  const onNodeDoubleClick = useCallback(
+    (_e: React.MouseEvent, node: Node) => {
+      if (node.type === 'webhook') {
+        setEditingId(node.id);
+      }
+    },
+    []
+  );
+
+  const handleSave = (data: WebhookNodeData) => {
+    setNodes((nds) => nds.map((n) => (n.id === editingId ? { ...n, data } : n)));
+  };
+
+  const editingNode = nodes.find((n) => n.id === editingId);
+
+  return (
+    <div className="w-full h-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        onNodeDoubleClick={onNodeDoubleClick}
+        nodeTypes={nodeTypes}
+        fitView
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+      {editingNode && (
+        <WebhookSettingsModal
+          data={editingNode.data}
+          baseTestUrl={baseTestUrl}
+          baseProdUrl={baseProdUrl}
+          onSave={handleSave}
+          onClose={() => setEditingId(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/WebhookSettingsModal.tsx
+++ b/src/components/WebhookSettingsModal.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import type { WebhookNodeData } from './nodes/WebhookNode';
+
+interface WebhookSettingsModalProps {
+  /** Existing data for the node being edited */
+  data: WebhookNodeData;
+  /** Called with updated data when the user saves */
+  onSave: (data: WebhookNodeData) => void;
+  /** Close the modal without saving */
+  onClose: () => void;
+  /** Base URLs used to build the test and production URLs */
+  baseTestUrl: string;
+  baseProdUrl: string;
+}
+
+/** Modal used to configure webhook nodes. */
+export default function WebhookSettingsModal({
+  data,
+  onSave,
+  onClose,
+  baseTestUrl,
+  baseProdUrl,
+}: WebhookSettingsModalProps) {
+  const [path, setPath] = useState(data.path || uuidv4());
+  const [method, setMethod] = useState(data.method || 'POST');
+  const [auth, setAuth] = useState(data.auth || 'None');
+  const [respond, setRespond] = useState(data.respond || 'Immediately');
+  const [prodUrl, setProdUrl] = useState(data.prodUrl || `${baseProdUrl}${path}`);
+  const [notes, setNotes] = useState(data.notes || '');
+  const [displayNote, setDisplayNote] = useState(data.displayNote ?? false);
+
+  const testUrl = `${baseTestUrl}${path}`;
+
+  const handleSave = () => {
+    onSave({
+      ...data,
+      path,
+      method,
+      auth,
+      respond,
+      prodUrl,
+      testUrl,
+      notes,
+      displayNote,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content space-y-4">
+        <h2 className="text-lg font-semibold">Webhook Settings</h2>
+        <div>
+          <label className="block text-sm font-medium mb-1">Test URL</label>
+          <input type="text" className="input" value={testUrl} readOnly />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Production URL</label>
+          <input
+            type="text"
+            className="input"
+            value={prodUrl}
+            onChange={(e) => setProdUrl(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">HTTP Method</label>
+          <select
+            className="input"
+            value={method}
+            onChange={(e) => setMethod(e.target.value)}
+          >
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+            <option value="DELETE">DELETE</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Path</label>
+          <input
+            type="text"
+            className="input"
+            value={path}
+            onChange={(e) => {
+              const value = e.target.value;
+              setPath(value);
+              // Keep URLs in sync when path changes
+              setProdUrl(`${baseProdUrl}${value}`);
+            }}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Authentication</label>
+          <select
+            className="input"
+            value={auth}
+            onChange={(e) => setAuth(e.target.value)}
+          >
+            <option value="None">None</option>
+            <option value="Basic">Basic</option>
+            <option value="Bearer">Bearer</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Respond</label>
+          <select
+            className="input"
+            value={respond}
+            onChange={(e) => setRespond(e.target.value)}
+          >
+            <option value="Immediately">Immediately</option>
+            <option value="After Workflow">After Workflow</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Notes</label>
+          <textarea
+            className="input h-24"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            id="display-note"
+            type="checkbox"
+            checked={displayNote}
+            onChange={(e) => setDisplayNote(e.target.checked)}
+          />
+          <label htmlFor="display-note" className="text-sm">
+            Display note in Flow
+          </label>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={handleSave}>
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nodes/WebhookNode.tsx
+++ b/src/components/nodes/WebhookNode.tsx
@@ -1,0 +1,42 @@
+import { memo } from 'react';
+import { Handle, Position } from 'reactflow';
+import type { NodeProps } from 'reactflow';
+import { FiLink, FiZap } from 'react-icons/fi';
+import { useThemeStore } from '../../store/themeStore';
+
+export interface WebhookNodeData {
+  path: string;
+  method: string;
+  auth: string;
+  respond: string;
+  testUrl: string;
+  prodUrl: string;
+  notes: string;
+  displayNote: boolean;
+  isListening: boolean;
+}
+
+/**
+ * Renders a square webhook node. When the node is actively listening for
+ * requests a small orange lightning bolt is displayed in the corner.
+ */
+function WebhookNode({ data }: NodeProps<WebhookNodeData>) {
+  const theme = useThemeStore((state) => state.theme);
+
+  return (
+    <div className={`webhook-node ${theme === 'dark' ? 'dark' : ''}`}>
+      {data.isListening && (
+        <FiZap className="absolute top-1 left-1 w-3 h-3 text-orange-500" />
+      )}
+      <FiLink className="w-6 h-6" />
+      <div className="text-xs mt-1">Webhook</div>
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="w-2 h-4 !rounded-none source-handle"
+      />
+    </div>
+  );
+}
+
+export default memo(WebhookNode);

--- a/src/index.css
+++ b/src/index.css
@@ -21,3 +21,20 @@ html, body, #root {
     @apply inline-flex items-center justify-center p-1 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-400;
   }
 }
+
+/* Webhook node styling */
+.webhook-node {
+  @apply relative flex flex-col items-center justify-center w-20 h-20 rounded-md border bg-white text-gray-800 dark:bg-gray-800 dark:text-gray-100 border-gray-300 dark:border-gray-700;
+}
+
+.modal-overlay {
+  @apply fixed inset-0 bg-black/50 flex items-center justify-center z-50;
+}
+
+.modal-content {
+  @apply bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg w-96;
+}
+
+.input {
+  @apply w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,6 +2226,11 @@ use-sync-external-store@^1.2.2:
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz"
   integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
 
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+
 vite@^6.3.5:
   version "6.3.5"
   resolved "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz"


### PR DESCRIPTION
## Summary
- add webhook node with listening indicator and theme support
- add modal for configuring webhook nodes
- add FlowCanvas wrapper integrating WebhookNode
- style node and modal with Tailwind
- include uuid dependency

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_684965c45f288320b5a84e3e56a6888e