### PR TITLE
Extend workflow node types and palette

### DIFF
--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -1,6 +1,20 @@
 import type { NodeType } from '../types/workflow';
 import { useWorkflowStore } from '../store/workflowStore';
-import { FiGlobe, FiClock, FiSliders, FiGitBranch, FiLink } from 'react-icons/fi';
+import {
+  FiGlobe,
+  FiClock,
+  FiSliders,
+  FiGitBranch,
+  FiLink,
+  FiCode,
+  FiGitMerge,
+  FiFilter,
+  FiZap,
+  FiList,
+  FiMail,
+  FiSettings,
+} from 'react-icons/fi';
+import { SiAirtable } from 'react-icons/si';
 import type { IconType } from 'react-icons';
 
 interface NodeTypeItem {
@@ -40,6 +54,54 @@ const nodeTypes: NodeTypeItem[] = [
     label: 'Webhook',
     description: 'Trigger workflow from external events',
     Icon: FiLink,
+  },
+  {
+    type: 'code',
+    label: 'Code',
+    description: 'Execute custom code snippets',
+    Icon: FiCode,
+  },
+  {
+    type: 'set',
+    label: 'Set',
+    description: 'Assign values within the workflow',
+    Icon: FiSettings,
+  },
+  {
+    type: 'merge',
+    label: 'Merge',
+    description: 'Combine multiple branches',
+    Icon: FiGitMerge,
+  },
+  {
+    type: 'if',
+    label: 'If',
+    description: 'Conditional branching logic',
+    Icon: FiFilter,
+  },
+  {
+    type: 'function',
+    label: 'Function',
+    description: 'Reusable workflow function',
+    Icon: FiZap,
+  },
+  {
+    type: 'functionItem',
+    label: 'Function Item',
+    description: 'Step inside a function',
+    Icon: FiList,
+  },
+  {
+    type: 'email',
+    label: 'Email',
+    description: 'Send an email message',
+    Icon: FiMail,
+  },
+  {
+    type: 'airtable',
+    label: 'Airtable',
+    description: 'Interact with Airtable records',
+    Icon: SiAirtable,
   },
 ];
 

--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -34,6 +34,14 @@ const nodeTypes: NodeTypes = {
   setVariable: StyledNode,
   condition: StyledNode,
   webhook: WebhookNode,
+  code: StyledNode,
+  set: StyledNode,
+  merge: StyledNode,
+  if: StyledNode,
+  function: StyledNode,
+  functionItem: StyledNode,
+  email: StyledNode,
+  airtable: StyledNode,
 };
 
 const edgeTypes = {

--- a/src/components/nodes/StyledNode.tsx
+++ b/src/components/nodes/StyledNode.tsx
@@ -9,7 +9,15 @@ import {
   FiGitBranch,
   FiLink,
   FiPlus,
+  FiCode,
+  FiGitMerge,
+  FiFilter,
+  FiZap,
+  FiList,
+  FiMail,
+  FiSettings,
 } from "react-icons/fi";
+import { SiAirtable } from "react-icons/si";
 import { useWorkflowStore } from "../../store/workflowStore";
 
 interface StyledNodeProps extends NodeProps<WorkflowNodeData> {
@@ -59,6 +67,14 @@ function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
     setVariable: FiSliders,
     condition: FiGitBranch,
     webhook: FiLink,
+    code: FiCode,
+    set: FiSettings,
+    merge: FiGitMerge,
+    if: FiFilter,
+    function: FiZap,
+    functionItem: FiList,
+    email: FiMail,
+    airtable: SiAirtable,
   } as const;
 
   const Icon = IconMap[data.type] ?? FiGlobe;

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -5,7 +5,15 @@ export type NodeType =
   | "delay"
   | "setVariable"
   | "condition"
-  | "webhook";
+  | "webhook"
+  | "code"
+  | "set"
+  | "merge"
+  | "if"
+  | "function"
+  | "functionItem"
+  | "email"
+  | "airtable";
 
 export interface WorkflowNodeData {
   label: string;


### PR DESCRIPTION
## Summary
- support additional node types in `NodeType`
- map new node components in `WorkflowEditor`
- provide icons and palette entries for the new nodes
- update `StyledNode` icon mapping for new node types

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_684ae47db5888320a3f2a8be02b8b7a9