### PR TITLE
Add additional workflow node components

### DIFF
--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -21,6 +21,15 @@ import type {
 } from "../types/workflow";
 import StyledNode from "./nodes/StyledNode";
 import WebhookNode from "./nodes/WebhookNode";
+import CodeNode from "./nodes/CodeNode";
+import SetNode from "./nodes/SetNode";
+import DelayNode from "./nodes/DelayNode";
+import MergeNode from "./nodes/MergeNode";
+import IfNode from "./nodes/IfNode";
+import FunctionNode from "./nodes/FunctionNode";
+import FunctionItemNode from "./nodes/FunctionItemNode";
+import EmailNode from "./nodes/EmailNode";
+import AirtableNode from "./nodes/AirtableNode";
 import GlobalAddButton from "./GlobalAddButton";
 import ButtonEdge from "./edges/ButtonEdge";
 import { getNodeId } from "../utils/getNodeId";
@@ -30,10 +39,18 @@ import HttpRequestNode from "./nodes/HttpRequestNode";
 
 const nodeTypes: NodeTypes = {
   httpRequest: HttpRequestNode,
-  delay: StyledNode,
+  delay: DelayNode,
   setVariable: StyledNode,
   condition: StyledNode,
   webhook: WebhookNode,
+  code: CodeNode,
+  set: SetNode,
+  merge: MergeNode,
+  if: IfNode,
+  function: FunctionNode,
+  functionItem: FunctionItemNode,
+  email: EmailNode,
+  airtable: AirtableNode,
 };
 
 const edgeTypes = {

--- a/src/components/nodes/AirtableNode.tsx
+++ b/src/components/nodes/AirtableNode.tsx
@@ -1,0 +1,2 @@
+import StyledNode from './StyledNode';
+export default StyledNode;

--- a/src/components/nodes/CodeNode.tsx
+++ b/src/components/nodes/CodeNode.tsx
@@ -1,0 +1,2 @@
+import StyledNode from './StyledNode';
+export default StyledNode;

--- a/src/components/nodes/DelayNode.tsx
+++ b/src/components/nodes/DelayNode.tsx
@@ -1,0 +1,2 @@
+import StyledNode from './StyledNode';
+export default StyledNode;

--- a/src/components/nodes/EmailNode.tsx
+++ b/src/components/nodes/EmailNode.tsx
@@ -1,0 +1,2 @@
+import StyledNode from './StyledNode';
+export default StyledNode;

--- a/src/components/nodes/FunctionItemNode.tsx
+++ b/src/components/nodes/FunctionItemNode.tsx
@@ -1,0 +1,2 @@
+import StyledNode from './StyledNode';
+export default StyledNode;

--- a/src/components/nodes/FunctionNode.tsx
+++ b/src/components/nodes/FunctionNode.tsx
@@ -1,0 +1,2 @@
+import StyledNode from './StyledNode';
+export default StyledNode;

--- a/src/components/nodes/IfNode.tsx
+++ b/src/components/nodes/IfNode.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect, memo } from 'react';
+import { Handle, Position } from 'reactflow';
+import type { NodeProps } from 'reactflow';
+import type { WorkflowNodeData } from '../../types/workflow';
+import { FiGitBranch, FiPlus } from 'react-icons/fi';
+import { useWorkflowStore } from '../../store/workflowStore';
+
+interface IfNodeProps extends NodeProps<WorkflowNodeData> {
+  darkMode?: boolean;
+}
+
+function IfNode({ id, data, darkMode = false }: IfNodeProps) {
+  const [isDark, setIsDark] = React.useState(darkMode);
+
+  const edges = useWorkflowStore((state) => state.edges);
+  const draggingNodeId = useWorkflowStore((state) => state.draggingNodeId);
+  const openSidebar = useWorkflowStore((state) => state.openSidebar);
+  const setPendingConnection = useWorkflowStore((state) => state.setPendingConnection);
+
+  const hasOutgoingTrue = edges.some((e) => e.source === id && e.sourceHandle === 'true');
+  const hasOutgoingFalse = edges.some((e) => e.source === id && e.sourceHandle === 'false');
+  const showPlusTrue = !hasOutgoingTrue && draggingNodeId !== id;
+  const showPlusFalse = !hasOutgoingFalse && draggingNodeId !== id;
+
+  const onAdd = (handleId: string) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPendingConnection({ source: id, sourceHandle: handleId });
+    openSidebar();
+  };
+
+  const colors = {
+    background: isDark ? '#1e2235' : '#fff',
+    border: isDark ? 'rgba(255,255,255,0.2)' : '#C1C1C1',
+    shadow: isDark ? '0 1px 4px rgba(0,0,0,0.5)' : '0 1px 4px rgba(0,0,0,0.1)',
+    text: isDark ? '#FFFFFF' : '#333333',
+  };
+
+  useEffect(() => {
+    if (!darkMode) {
+      const prefersDark =
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setIsDark(prefersDark);
+    }
+  }, [darkMode]);
+
+  return (
+    <div>
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="w-3 h-3 bg-gray-400 border-2 border-gray-600"
+      />
+
+      <div className={`flex items-center p-4 shadow-lg rounded-sm border-1 bg-[${colors.background}]`}>
+        <FiGitBranch className="w-6 h-6 text-blue-600" />
+      </div>
+
+      <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
+        <div className="font-medium text-[8px]">{data.label}</div>
+      </div>
+
+      <Handle
+        type="source"
+        id="true"
+        position={Position.Right}
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          border: `2px solid ${colors.border}`,
+          background: colors.background,
+          right: 0,
+          top: '35%',
+          transform: 'translate(50%, -50%)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: colors.text,
+          fontSize: 14,
+        }}
+      >
+        {showPlusTrue && (
+          <>
+            <div
+              style={{
+                position: 'absolute',
+                right: -30,
+                top: '50%',
+                width: 30,
+                height: 2,
+                background: colors.border,
+                transform: 'translateY(-50%)',
+                pointerEvents: 'none',
+              }}
+            />
+            <FiPlus
+              onClick={onAdd('true')}
+              style={{
+                position: 'absolute',
+                right: -45,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                width: 20,
+                height: 20,
+                border: `2px solid ${colors.border}`,
+                borderRadius: 4,
+                padding: 2,
+                background: colors.background,
+                color: colors.text,
+                cursor: 'pointer',
+              }}
+            />
+          </>
+        )}
+      </Handle>
+
+      <Handle
+        type="source"
+        id="false"
+        position={Position.Right}
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          border: `2px solid ${colors.border}`,
+          background: colors.background,
+          right: 0,
+          top: '65%',
+          transform: 'translate(50%, -50%)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: colors.text,
+          fontSize: 14,
+        }}
+      >
+        {showPlusFalse && (
+          <>
+            <div
+              style={{
+                position: 'absolute',
+                right: -30,
+                top: '50%',
+                width: 30,
+                height: 2,
+                background: colors.border,
+                transform: 'translateY(-50%)',
+                pointerEvents: 'none',
+              }}
+            />
+            <FiPlus
+              onClick={onAdd('false')}
+              style={{
+                position: 'absolute',
+                right: -45,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                width: 20,
+                height: 20,
+                border: `2px solid ${colors.border}`,
+                borderRadius: 4,
+                padding: 2,
+                background: colors.background,
+                color: colors.text,
+                cursor: 'pointer',
+              }}
+            />
+          </>
+        )}
+      </Handle>
+    </div>
+  );
+}
+
+export default memo(IfNode);

--- a/src/components/nodes/MergeNode.tsx
+++ b/src/components/nodes/MergeNode.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, memo } from 'react';
+import { Handle, Position } from 'reactflow';
+import type { NodeProps } from 'reactflow';
+import type { WorkflowNodeData } from '../../types/workflow';
+import { FiGitMerge, FiPlus } from 'react-icons/fi';
+import { useWorkflowStore } from '../../store/workflowStore';
+
+interface MergeNodeProps extends NodeProps<WorkflowNodeData> {
+  darkMode?: boolean;
+}
+
+function MergeNode({ id, data, darkMode = false }: MergeNodeProps) {
+  const [isDark, setIsDark] = React.useState(darkMode);
+
+  const edges = useWorkflowStore((state) => state.edges);
+  const draggingNodeId = useWorkflowStore((state) => state.draggingNodeId);
+  const openSidebar = useWorkflowStore((state) => state.openSidebar);
+  const setPendingConnection = useWorkflowStore((state) => state.setPendingConnection);
+  const hasOutgoing = edges.some((e) => e.source === id);
+  const showPlus = !hasOutgoing && draggingNodeId !== id;
+  const onAdd = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPendingConnection({ source: id, sourceHandle: 'out' });
+    openSidebar();
+  };
+  const colors = {
+    background: isDark ? '#1e2235' : '#fff',
+    border: isDark ? 'rgba(255,255,255,0.2)' : '#C1C1C1',
+    shadow: isDark ? '0 1px 4px rgba(0,0,0,0.5)' : '0 1px 4px rgba(0,0,0,0.1)',
+    text: isDark ? '#FFFFFF' : '#333333',
+  };
+
+  useEffect(() => {
+    if (!darkMode) {
+      const prefersDark =
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setIsDark(prefersDark);
+    }
+  }, [darkMode]);
+
+  return (
+    <div>
+      <Handle
+        type="target"
+        id="in1"
+        position={Position.Left}
+        style={{ top: '30%' }}
+        className="w-3 h-3 bg-gray-400 border-2 border-gray-600"
+      />
+      <Handle
+        type="target"
+        id="in2"
+        position={Position.Left}
+        style={{ top: '70%' }}
+        className="w-3 h-3 bg-gray-400 border-2 border-gray-600"
+      />
+
+      <div className={`flex items-center p-4 shadow-lg rounded-sm border-1 bg-[${colors.background}]`}>
+        <FiGitMerge className="w-6 h-6 text-blue-600" />
+      </div>
+
+      <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
+        <div className="font-medium text-[8px]">{data.label}</div>
+      </div>
+
+      <Handle
+        type="source"
+        id="out"
+        position={Position.Right}
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          border: `2px solid ${colors.border}`,
+          background: colors.background,
+          right: 0,
+          top: '50%',
+          transform: 'translate(50%, -50%)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: colors.text,
+          fontSize: 14,
+        }}
+      >
+        {showPlus && (
+          <>
+            <div
+              style={{
+                position: 'absolute',
+                right: -30,
+                top: '50%',
+                width: 30,
+                height: 2,
+                background: colors.border,
+                transform: 'translateY(-50%)',
+                pointerEvents: 'none',
+              }}
+            />
+            <FiPlus
+              onClick={onAdd}
+              style={{
+                position: 'absolute',
+                right: -45,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                width: 20,
+                height: 20,
+                border: `2px solid ${colors.border}`,
+                borderRadius: 4,
+                padding: 2,
+                background: colors.background,
+                color: colors.text,
+                cursor: 'pointer',
+              }}
+            />
+          </>
+        )}
+      </Handle>
+    </div>
+  );
+}
+
+export default memo(MergeNode);

--- a/src/components/nodes/SetNode.tsx
+++ b/src/components/nodes/SetNode.tsx
@@ -1,0 +1,2 @@
+import StyledNode from './StyledNode';
+export default StyledNode;

--- a/src/components/nodes/StyledNode.tsx
+++ b/src/components/nodes/StyledNode.tsx
@@ -9,6 +9,11 @@ import {
   FiGitBranch,
   FiLink,
   FiPlus,
+  FiCode,
+  FiGitMerge,
+  FiCpu,
+  FiMail,
+  FiGrid,
 } from "react-icons/fi";
 import { useWorkflowStore } from "../../store/workflowStore";
 
@@ -59,6 +64,14 @@ function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
     setVariable: FiSliders,
     condition: FiGitBranch,
     webhook: FiLink,
+    code: FiCode,
+    set: FiSliders,
+    merge: FiGitMerge,
+    if: FiGitBranch,
+    function: FiCpu,
+    functionItem: FiCpu,
+    email: FiMail,
+    airtable: FiGrid,
   } as const;
 
   const Icon = IconMap[data.type] ?? FiGlobe;

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -5,7 +5,15 @@ export type NodeType =
   | "delay"
   | "setVariable"
   | "condition"
-  | "webhook";
+  | "webhook"
+  | "code"
+  | "set"
+  | "merge"
+  | "if"
+  | "function"
+  | "functionItem"
+  | "email"
+  | "airtable";
 
 export interface WorkflowNodeData {
   label: string;


### PR DESCRIPTION
## Summary
- extend supported node types
- add icons for extra node types
- implement MergeNode and IfNode
- add simple wrappers for other node components
- register new nodes in the workflow editor

## Testing
- `yarn build` *(fails: Request failed "503 Service Unavailable")*
- `yarn install` *(fails: Request failed "503 Service Unavailable")*

------
https://chatgpt.com/codex/tasks/task_e_684b1e046bf483208829c02e23fe8a45