### PR TITLE
Refactor properties for separate components

### DIFF
--- a/src/components/AirtableSettings.tsx
+++ b/src/components/AirtableSettings.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+interface AirtableSettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function AirtableSettings({ data, onChange }: AirtableSettingsProps) {
+  return (
+    <div className="space-y-4 text-left">
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">API Key</label>
+        <input
+          type="text"
+          value={(data.apiKey as string) || ''}
+          onChange={(e) => onChange('apiKey', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Base ID</label>
+        <input
+          type="text"
+          value={(data.baseId as string) || ''}
+          onChange={(e) => onChange('baseId', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Table</label>
+        <input
+          type="text"
+          value={(data.table as string) || ''}
+          onChange={(e) => onChange('table', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Operation</label>
+        <select
+          value={(data.operation as string) || 'select'}
+          onChange={(e) => onChange('operation', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        >
+          <option value="select">Select</option>
+          <option value="create">Create</option>
+          <option value="update">Update</option>
+          <option value="delete">Delete</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Fields (JSON)</label>
+        <textarea
+          value={(data.fields as string) || ''}
+          onChange={(e) => onChange('fields', e.target.value)}
+          className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Filter Formula</label>
+        <input
+          type="text"
+          value={(data.filter as string) || ''}
+          onChange={(e) => onChange('filter', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/CodeSettings.tsx
+++ b/src/components/CodeSettings.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface CodeSettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function CodeSettings({ data, onChange }: CodeSettingsProps) {
+  return (
+    <div className="space-y-4 text-left">
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Language</label>
+        <select
+          value={(data.language as string) || 'javascript'}
+          onChange={(e) => onChange('language', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        >
+          <option value="javascript">JavaScript</option>
+          <option value="typescript">TypeScript</option>
+          <option value="python">Python</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Mode</label>
+        <select
+          value={(data.mode as string) || 'full'}
+          onChange={(e) => onChange('mode', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        >
+          <option value="full">Full</option>
+          <option value="inline">Inline</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Code</label>
+        <textarea
+          value={(data.code as string) || ''}
+          onChange={(e) => onChange('code', e.target.value)}
+          className="w-full h-32 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/DelaySettings.tsx
+++ b/src/components/DelaySettings.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface DelaySettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function DelaySettings({ data, onChange }: DelaySettingsProps) {
+  return (
+    <div className="space-y-4 text-left">
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Duration (ms)</label>
+        <input
+          type="number"
+          value={(data.duration as number | undefined) ?? ''}
+          onChange={(e) => onChange('duration', Number(e.target.value))}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Until</label>
+        <input
+          type="datetime-local"
+          value={(data.until as string) || ''}
+          onChange={(e) => onChange('until', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/EmailSettings.tsx
+++ b/src/components/EmailSettings.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+interface EmailSettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function EmailSettings({ data, onChange }: EmailSettingsProps) {
+  return (
+    <div className="space-y-4 text-left">
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">SMTP Host</label>
+        <input
+          type="text"
+          value={(data.smtpHost as string) || ''}
+          onChange={(e) => onChange('smtpHost', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">Port</label>
+          <input
+            type="number"
+            value={(data.smtpPort as number | undefined) ?? ''}
+            onChange={(e) => onChange('smtpPort', Number(e.target.value))}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div className="flex items-center gap-2 mt-6">
+          <input
+            type="checkbox"
+            checked={Boolean(data.smtpSecure)}
+            onChange={(e) => onChange('smtpSecure', e.target.checked)}
+          />
+          <span className="text-sm">Secure</span>
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Username</label>
+        <input
+          type="text"
+          value={(data.smtpUser as string) || ''}
+          onChange={(e) => onChange('smtpUser', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Password</label>
+        <input
+          type="password"
+          value={(data.smtpPass as string) || ''}
+          onChange={(e) => onChange('smtpPass', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">From</label>
+        <input
+          type="text"
+          value={(data.from as string) || ''}
+          onChange={(e) => onChange('from', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">To</label>
+        <input
+          type="text"
+          value={(data.to as string) || ''}
+          onChange={(e) => onChange('to', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Subject</label>
+        <input
+          type="text"
+          value={(data.subject as string) || ''}
+          onChange={(e) => onChange('subject', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Body</label>
+        <textarea
+          value={(data.body as string) || ''}
+          onChange={(e) => onChange('body', e.target.value)}
+          className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Attachments (comma separated URLs)</label>
+        <input
+          type="text"
+          value={(data.attachments as string) || ''}
+          onChange={(e) => onChange('attachments', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/HttpRequestSettings.tsx
+++ b/src/components/HttpRequestSettings.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+interface HttpRequestSettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function HttpRequestSettings({ data, onChange }: HttpRequestSettingsProps) {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const content = event.target?.result;
+        onChange('fileName', file.name);
+        onChange('fileContent', content);
+      };
+      reader.readAsArrayBuffer(file);
+    }
+  };
+
+  return (
+    <div className="space-y-4 text-left">
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Method</label>
+        <select
+          value={(data.method as string) || 'GET'}
+          onChange={(e) => onChange('method', e.target.value)}
+          className="w-full px-3 py-2  border border-gray-600 rounded-md"
+        >
+          {['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].map((m) => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">URL</label>
+        <input
+          type="text"
+          value={(data.url as string) || ''}
+          onChange={(e) => onChange('url', e.target.value)}
+          placeholder="https://api.example.com/endpoint"
+          className="w-full px-3 py-2  border border-gray-600 rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Headers (JSON)</label>
+        <textarea
+          value={(data.headers as string) || ''}
+          onChange={(e) => onChange('headers', e.target.value)}
+          placeholder='{"Content-Type": "application/json"}'
+          className="w-full h-24 px-3 py-2  border border-gray-600 rounded-md  font-mono text-sm"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Body</label>
+        <textarea
+          value={(data.body as string) || ''}
+          onChange={(e) => onChange('body', e.target.value)}
+          placeholder="{name: 'John Doe'}"
+          className="w-full h-32 px-3 py-2  border border-gray-600 rounded-md font-mono text-sm"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">File Upload (optional)</label>
+        <input
+          type="file"
+          onChange={handleFileChange}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          value={undefined}
+        />
+        {data.fileName && (
+          <div className="mt-2 text-xs text-gray-700">Selected file: {data.fileName as string}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/IfSettings.tsx
+++ b/src/components/IfSettings.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+interface IfSettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function IfSettings({ data, onChange }: IfSettingsProps) {
+  const conditions = (data.conditions as Array<{ left: string; op: string; right: string }> | undefined) || [];
+
+  const handleConditionChange = (index: number, key: 'left' | 'op' | 'right', value: string) => {
+    const newConditions = conditions.map((c, i) => (i === index ? { ...c, [key]: value } : c));
+    onChange('conditions', newConditions);
+  };
+
+  const addCondition = () => {
+    onChange('conditions', [...conditions, { left: '', op: '==', right: '' }]);
+  };
+
+  const removeCondition = (index: number) => {
+    const newConditions = conditions.filter((_, i) => i !== index);
+    onChange('conditions', newConditions);
+  };
+
+  return (
+    <div className="space-y-2 text-left">
+      {conditions.map((c, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <input
+            type="text"
+            value={c.left}
+            onChange={(e) => handleConditionChange(idx, 'left', e.target.value)}
+            placeholder="Field"
+            className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+          />
+          <select
+            value={c.op}
+            onChange={(e) => handleConditionChange(idx, 'op', e.target.value)}
+            className="px-2 py-1 border border-gray-600 rounded-md"
+          >
+            <option value="==">==</option>
+            <option value="!=">!=</option>
+            <option value=">">&gt;</option>
+            <option value="<">&lt;</option>
+          </select>
+          <input
+            type="text"
+            value={c.right}
+            onChange={(e) => handleConditionChange(idx, 'right', e.target.value)}
+            placeholder="Value"
+            className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+          />
+          <button
+            onClick={() => removeCondition(idx)}
+            className="px-2 py-1 text-xs bg-red-500 text-white rounded"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <button onClick={addCondition} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">
+        Add Condition
+      </button>
+      <div className="mt-2">
+        <label className="block text-sm font-medium text-gray-600 mb-1">Match</label>
+        <select
+          value={(data.andOr as string) || 'AND'}
+          onChange={(e) => onChange('andOr', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        >
+          <option value="AND">AND</option>
+          <option value="OR">OR</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MergeSettings.tsx
+++ b/src/components/MergeSettings.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface MergeSettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function MergeSettings({ data, onChange }: MergeSettingsProps) {
+  return (
+    <div className="space-y-4 text-left">
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Mode</label>
+        <select
+          value={(data.mergeMode as string) || 'append'}
+          onChange={(e) => onChange('mergeMode', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        >
+          <option value="append">Append</option>
+          <option value="combine">Combine</option>
+          <option value="overwrite">Overwrite</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-600 mb-2">Fields</label>
+        <input
+          type="text"
+          value={(data.mergeFields as string) || ''}
+          onChange={(e) => onChange('mergeFields', e.target.value)}
+          placeholder="Comma separated fields"
+          className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,7 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FiSettings, FiArrowLeft } from 'react-icons/fi';
 import type { Node } from 'reactflow';
 import WebhookSettings from './WebhookSettings';
+import HttpRequestSettings from './HttpRequestSettings';
+import CodeSettings from './CodeSettings';
+import SetSettings from './SetSettings';
+import DelaySettings from './DelaySettings';
+import MergeSettings from './MergeSettings';
+import IfSettings from './IfSettings';
+import EmailSettings from './EmailSettings';
+import AirtableSettings from './AirtableSettings';
 
 interface PropertiesPanelProps {
   node: Node;
@@ -10,10 +18,8 @@ interface PropertiesPanelProps {
 }
 
 export default function PropertiesPanel({ node, onUpdateNode, onClose }: PropertiesPanelProps) {
-  // Local state for form inputs to ensure smooth typing
   const [formData, setFormData] = useState(node.data);
 
-  // Update local state when node changes
   useEffect(() => {
     setFormData(node.data);
   }, [node]);
@@ -24,95 +30,28 @@ export default function PropertiesPanel({ node, onUpdateNode, onClose }: Propert
     onUpdateNode(node.id, { [field]: value });
   };
 
-  // Handle file input for HTTP request
-  const handleHttpFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        const content = event.target?.result;
-        const newFormData = {
-          ...formData,
-          fileName: file.name,
-          fileContent: content,
-        };
-        setFormData(newFormData);
-        onUpdateNode(node.id, { fileName: file.name, fileContent: content });
-      };
-      reader.readAsArrayBuffer(file); // Use ArrayBuffer for binary support
-    }
-  };
-
-  const renderHttpRequestProperties = () => (
-    <div className="space-y-4 text-left">
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Method</label>
-        <select
-          value={formData.method || 'GET'}
-          onChange={(e) => handleInputChange('method', e.target.value)}
-          className="w-full px-3 py-2  border border-gray-600 rounded-md"
-        >
-          <option value="GET">GET</option>
-          <option value="POST">POST</option>
-          <option value="PUT">PUT</option>
-          <option value="DELETE">DELETE</option>
-          <option value="PATCH">PATCH</option>
-        </select>
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">URL</label>
-        <input
-          type="text"
-          value={formData.url || ''}
-          onChange={(e) => handleInputChange('url', e.target.value)}
-          placeholder="https://api.example.com/endpoint"
-          className="w-full px-3 py-2  border border-gray-600 rounded-md"
-        />
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Headers (JSON)</label>
-        <textarea
-          value={formData.headers}
-          onChange={(e) => handleInputChange('headers', e.target.value)}
-          placeholder='{"Content-Type": "application/json", "Authorization": "Bearer token"}'
-          className="w-full h-24 px-3 py-2  border border-gray-600 rounded-md  font-mono text-sm"
-        />
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Body</label>
-        <textarea
-          value={formData.body || ''}
-          onChange={(e) => handleInputChange('body', e.target.value)}
-          placeholder="{name: 'John Doe', age: 30}"
-          className="w-full h-32 px-3 py-2  border border-gray-600 rounded-md font-mono text-sm"
-        />
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">File Upload (optional)</label>
-        <input
-          type="file"
-          onChange={handleHttpFileChange}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-          value={undefined} // Prevent React warning, file inputs are always uncontrolled
-        />
-        {formData.fileName && (
-          <div className="mt-2 text-xs text-gray-700">Selected file: {formData.fileName}</div>
-        )}
-      </div>
-    </div>
-  );
-
-
   const renderProperties = () => {
     switch (node.type) {
       case 'httpRequest':
-        return renderHttpRequestProperties();
+        return <HttpRequestSettings data={formData} onChange={handleInputChange} />;
       case 'webhook':
         return <WebhookSettings data={formData} onChange={handleInputChange} />;
+      case 'code':
+      case 'function':
+      case 'functionItem':
+        return <CodeSettings data={formData} onChange={handleInputChange} />;
+      case 'set':
+        return <SetSettings data={formData} onChange={handleInputChange} />;
+      case 'delay':
+        return <DelaySettings data={formData} onChange={handleInputChange} />;
+      case 'merge':
+        return <MergeSettings data={formData} onChange={handleInputChange} />;
+      case 'if':
+        return <IfSettings data={formData} onChange={handleInputChange} />;
+      case 'email':
+        return <EmailSettings data={formData} onChange={handleInputChange} />;
+      case 'airtable':
+        return <AirtableSettings data={formData} onChange={handleInputChange} />;
       default:
         return <div className="text-gray-400">No properties available</div>;
     }
@@ -145,39 +84,42 @@ export default function PropertiesPanel({ node, onUpdateNode, onClose }: Propert
   };
 
   return (
-    <div className='fixed inset-0 bg-[#444257bf] z-90' onClick={onClose}>
-      <span className='text-white flex items-center gap-2 cursor-pointer absolute top-2 left-4 p-2'
-        onClick={onClose}>
-        <FiArrowLeft className="w-5 h-5 text-white"/>
+    <div className="fixed inset-0 bg-[#444257bf] z-90" onClick={onClose}>
+      <span
+        className="text-white flex items-center gap-2 cursor-pointer absolute top-2 left-4 p-2"
+        onClick={onClose}
+      >
+        <FiArrowLeft className="w-5 h-5 text-white" />
         Back to canvas
       </span>
-    <div className="p-6 flex items-center justify-center z-50 my-8 h-[calc(100%-64px)]" onClick={(e) => e.stopPropagation()}>
-      <div className='bg-[#f1f3f9] h-full  w-[30%] p-4 rounded-tl-lg flex items-center justify-center'>
-        {renderInputSection()}
-      </div>
-      <div className="w-96 rounded-lg border border-gray-300 flex flex-col w-[40%] h-[calc(100%+48px)]">
-        <div className="p-4 flex items-center justify-between bg-[#f1f3f9] rounded-tl-lg rounded-tr-lg">
-          <div className="flex items-center gap-2">
-            <FiSettings className="w-5 h-5 text-blue-500" />
-            <h2 className="text-lg font-semibold text-gray-800">Properties</h2>
+      <div
+        className="p-6 flex items-center justify-center z-50 my-8 h-[calc(100%-64px)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="bg-[#f1f3f9] h-full  w-[30%] p-4 rounded-tl-lg flex items-center justify-center">
+          {renderInputSection()}
+        </div>
+        <div className="w-96 rounded-lg border border-gray-300 flex flex-col w-[40%] h-[calc(100%+48px)]">
+          <div className="p-4 flex items-center justify-between bg-[#f1f3f9] rounded-tl-lg rounded-tr-lg">
+            <div className="flex items-center gap-2">
+              <FiSettings className="w-5 h-5 text-blue-500" />
+              <h2 className="text-lg font-semibold text-gray-800">Properties</h2>
+            </div>
+          </div>
+          <div className="flex-1 p-4 overflow-y-auto bg-white rounded-bl-lg rounded-br-lg">
+            <div className="mb-4">
+              <h3 className="font-medium text-gray-800 mb-2">Node: {formData.label}</h3>
+              <p className="text-sm text-gray-400">ID: {node.id}</p>
+            </div>
+            {renderProperties()}
           </div>
         </div>
-
-        <div className="flex-1 p-4 overflow-y-auto bg-white rounded-bl-lg rounded-br-lg">
-          <div className="mb-4">
-            <h3 className="font-medium text-gray-800 mb-2">Node: {formData.label}</h3>
-            <p className="text-sm text-gray-400">ID: {node.id}</p>
-          </div>
-
-          {renderProperties()}
+        <div className="bg-[#f1f3f9] h-full  w-[30%] p-4 rounded-tr-lg">
+          <h6 className="tracking-[3px] uppercase text-md text-left font-semibold text-[#909298]">
+            Output
+          </h6>
         </div>
       </div>
-      <div className='bg-[#f1f3f9] h-full  w-[30%] p-4 rounded-tr-lg'>
-        <h6 className='tracking-[3px] uppercase text-md text-left font-semibold text-[#909298]'>
-          Output
-        </h6>
-      </div>
-    </div>
     </div>
   );
 }

--- a/src/components/SetSettings.tsx
+++ b/src/components/SetSettings.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+interface SetSettingsProps {
+  data: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+export default function SetSettings({ data, onChange }: SetSettingsProps) {
+  const mappings = (data.mappings as Array<{ field: string; value: string }> | undefined) || [];
+
+  const handleMappingChange = (index: number, key: 'field' | 'value', value: string) => {
+    const newMappings = mappings.map((m, i) => (i === index ? { ...m, [key]: value } : m));
+    onChange('mappings', newMappings);
+  };
+
+  const addMapping = () => {
+    onChange('mappings', [...mappings, { field: '', value: '' }]);
+  };
+
+  const removeMapping = (index: number) => {
+    const newMappings = mappings.filter((_, i) => i !== index);
+    onChange('mappings', newMappings);
+  };
+
+  return (
+    <div className="space-y-2 text-left">
+      {mappings.map((map, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <input
+            type="text"
+            value={map.field}
+            onChange={(e) => handleMappingChange(idx, 'field', e.target.value)}
+            placeholder="Field"
+            className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+          />
+          <input
+            type="text"
+            value={map.value}
+            onChange={(e) => handleMappingChange(idx, 'value', e.target.value)}
+            placeholder="Value"
+            className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+          />
+          <button
+            onClick={() => removeMapping(idx)}
+            className="px-2 py-1 text-xs bg-red-500 text-white rounded"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <button onClick={addMapping} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">
+        Add Field
+      </button>
+      <div className="flex items-center gap-2 mt-2">
+        <input
+          type="checkbox"
+          checked={Boolean(data.keepOnlySetFields)}
+          onChange={(e) => onChange('keepOnlySetFields', e.target.checked)}
+        />
+        <span className="text-sm">Keep Only Set Fields</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nodes/BaseNode.tsx
+++ b/src/components/nodes/BaseNode.tsx
@@ -3,7 +3,18 @@ import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { WorkflowNodeData } from '../../types/workflow';
 import { useWorkflowStore } from '../../store/workflowStore';
-import { FiGlobe, FiClock, FiSliders, FiGitBranch, FiLink } from 'react-icons/fi';
+import {
+  FiGlobe,
+  FiClock,
+  FiSliders,
+  FiGitBranch,
+  FiLink,
+  FiCode,
+  FiGitMerge,
+  FiCpu,
+  FiMail,
+  FiGrid,
+} from 'react-icons/fi';
 
 function BaseNode({ id, data }: NodeProps<WorkflowNodeData>) {
   const openSidebar = useWorkflowStore((state) => state.openSidebar);
@@ -15,6 +26,14 @@ function BaseNode({ id, data }: NodeProps<WorkflowNodeData>) {
     setVariable: FiSliders,
     condition: FiGitBranch,
     webhook: FiLink,
+    code: FiCode,
+    set: FiSliders,
+    merge: FiGitMerge,
+    if: FiGitBranch,
+    function: FiCpu,
+    functionItem: FiCpu,
+    email: FiMail,
+    airtable: FiGrid,
   } as const;
 
   const Icon = IconMap[data.type];
@@ -51,4 +70,4 @@ function BaseNode({ id, data }: NodeProps<WorkflowNodeData>) {
   );
 }
 
-export default memo(BaseNode); 
+export default memo(BaseNode);

--- a/src/components/nodes/StyledNode.tsx
+++ b/src/components/nodes/StyledNode.tsx
@@ -15,7 +15,6 @@ import {
   FiMail,
   FiGrid,
 } from "react-icons/fi";
-import { SiAirtable } from "react-icons/si";
 import { useWorkflowStore } from "../../store/workflowStore";
 
 interface StyledNodeProps extends NodeProps<WorkflowNodeData> {


### PR DESCRIPTION
## Summary
- move HTTP request and new node property forms into individual components
- render node property components based on node type

## Testing
- `yarn lint` *(fails: Cannot find package '@eslint/js')*
- `yarn build` *(fails: TS2307 Cannot find module 'reactflow')*

------
https://chatgpt.com/codex/tasks/task_e_684baef68dcc8320abf5e79a0a8a3521