### PR TITLE
Use Tailwind dark variants for node theming

### DIFF
--- a/src/components/edges/ButtonEdge.tsx
+++ b/src/components/edges/ButtonEdge.tsx
@@ -26,7 +26,6 @@ export function ButtonEdge({
     targetPosition,
   });
 
-  const theme = localStorage.getItem("theme");
 
   const [hovered, setHovered] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -81,18 +80,7 @@ export function ButtonEdge({
               onClick={onAdd}
               aria-label="Add node"
               title="Add node"
-              style={{
-                borderRadius: 4,
-                padding: 2,
-                border:
-                  theme === "dark"
-                    ? "2px solid rgba(255,255,255,0.2)"
-                    : "2px solid #ccc",
-                background: theme === "dark" ? "#1E2235" : "#ffffff",
-                color: theme === "dark" ? "#ffffff" : "#333333",
-                cursor: "pointer",
-              }}
-              className="cursor-pointer"
+              className="cursor-pointer rounded border-2 p-[2px] bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100"
             >
               <FiPlus size={5} className="pointer-events-none" />
             </button>
@@ -102,18 +90,7 @@ export function ButtonEdge({
               onClick={onDelete}
               aria-label="Delete edge"
               title="Delete edge"
-              className="cursor-pointer"
-              style={{
-                borderRadius: 4,
-                padding: 2,
-                border:
-                  theme === "dark"
-                    ? "2px solid rgba(255,255,255,0.2)"
-                    : "2px solid #ccc",
-                background: theme === "dark" ? "#1E2235" : "#ffffff",
-                color: theme === "dark" ? "#ffffff" : "#333333",
-                cursor: "pointer",
-              }}
+              className="cursor-pointer rounded border-2 p-[2px] bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100"
             >
               <FiTrash2 size={5} className="pointer-events-none" />
             </button>

--- a/src/components/edges/ButtonEdge.tsx
+++ b/src/components/edges/ButtonEdge.tsx
@@ -74,13 +74,13 @@ export function ButtonEdge({
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
               pointerEvents: "all",
             }}
-            className="flex items-center gap-0.5 bg-background cursor-pointer"
+            className="flex items-center gap-0.5 bg-white dark:bg-[#1e2235] cursor-pointer"
           >
             <button
               onClick={onAdd}
               aria-label="Add node"
               title="Add node"
-              className="cursor-pointer rounded border-2 p-[2px] bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100"
+              className="cursor-pointer rounded border-2 p-[2px] bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100"
             >
               <FiPlus size={5} className="pointer-events-none" />
             </button>
@@ -90,7 +90,7 @@ export function ButtonEdge({
               onClick={onDelete}
               aria-label="Delete edge"
               title="Delete edge"
-              className="cursor-pointer rounded border-2 p-[2px] bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100"
+              className="cursor-pointer rounded border-2 p-[2px] bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100"
             >
               <FiTrash2 size={5} className="pointer-events-none" />
             </button>

--- a/src/components/nodes/BaseNode.tsx
+++ b/src/components/nodes/BaseNode.tsx
@@ -47,7 +47,7 @@ function BaseNode({ id, data }: NodeProps<WorkflowNodeData>) {
 
   return (
     <div className="relative flex flex-col items-center">
-      <div className="relative bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md px-3 py-2 shadow">
+      <div className="relative bg-white dark:bg-[#1e2235] border border-gray-300 dark:border-white/20 rounded-md px-3 py-2 shadow">
         <Handle
           type="target"
           position={Position.Left}

--- a/src/components/nodes/HttpRequestNode.tsx
+++ b/src/components/nodes/HttpRequestNode.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import {
@@ -8,18 +7,8 @@ import {
 import { useWorkflowStore } from "../../store/workflowStore";
 
 export default function HttpRequestNode({ id, data }: NodeProps) {
-  const [darkMode, setDarkMode] = React.useState(false);
 
   const method = data.method || 'GET';
-
-    const colors = {
-    background: darkMode ? "#1e2235" : "#fff",
-    border: darkMode ? "rgba(255,255,255,0.2)" : "#C1C1C1",
-    shadow: darkMode
-      ? "0 1px 4px rgba(0,0,0,0.5)"
-      : "0 1px 4px rgba(0,0,0,0.1)",
-    text: darkMode ? "#FFFFFF" : "#333333",
-  };
 
   const edges = useWorkflowStore((state) => state.edges);
   const draggingNodeId = useWorkflowStore((state) => state.draggingNodeId);
@@ -34,20 +23,16 @@ export default function HttpRequestNode({ id, data }: NodeProps) {
     setPendingConnection({ source: id, sourceHandle: "out" });
     openSidebar();
   };
-  useEffect(() => {
-    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    setDarkMode(prefersDark);
-  }, []);
 
   return (
-    <div className={``}>
+    <div>
       <Handle
         type="target"
         position={Position.Left}
         className="w-3 h-3 bg-gray-400 border-2 border-gray-600"
       />
       
-      <div className={`flex items-center p-4 shadow-lg rounded-sm border-1 bg-[${colors.background}]`}>
+      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600">
         <FiGlobe className="w-6 h-6 text-blue-600" />
       </div>
       <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
@@ -65,55 +50,17 @@ export default function HttpRequestNode({ id, data }: NodeProps) {
         </div>
 
       <Handle
-              type="source"
-              id="out"
-              position={Position.Right}
-              style={{
-                width: 10,
-                height: 10,
-                borderRadius: "50%",
-                border: `2px solid ${colors.border}`,
-                background: colors.background,
-                right: 0,
-                top: "50%",
-                transform: "translate(50%, -50%)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                color: colors.text,
-                fontSize: 14,
-              }}
-            >
+        type="source"
+        id="out"
+        position={Position.Right}
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
+      >
               {showPlus && (
                 <>
-                  <div
-                    style={{
-                      position: "absolute",
-                      right: -30,
-                      top: "50%",
-                      width: 30,
-                      height: 2,
-                      background: colors.border,
-                      transform: "translateY(-50%)",
-                      pointerEvents: "none",
-                    }}
-                  />
+                  <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
                   <FiPlus
                     onClick={onAdd}
-                    style={{
-                      position: "absolute",
-                      right: -45,
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      width: 20,
-                      height: 20,
-                      border: `2px solid ${colors.border}`,
-                      borderRadius: 4,
-                      padding: 2,
-                      background: colors.background,
-                      color: colors.text,
-                      cursor: "pointer",
-                    }}
+                    className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
                   />
                 </>
               )}

--- a/src/components/nodes/HttpRequestNode.tsx
+++ b/src/components/nodes/HttpRequestNode.tsx
@@ -32,7 +32,7 @@ export default function HttpRequestNode({ id, data }: NodeProps) {
         className="w-3 h-3 bg-gray-400 border-2 border-gray-600"
       />
       
-      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600">
+      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20">
         <FiGlobe className="w-6 h-6 text-blue-600" />
       </div>
       <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
@@ -53,14 +53,14 @@ export default function HttpRequestNode({ id, data }: NodeProps) {
         type="source"
         id="out"
         position={Position.Right}
-        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
       >
               {showPlus && (
                 <>
-                  <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
+                  <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-white/20" />
                   <FiPlus
                     onClick={onAdd}
-                    className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
+                    className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-white/20 bg-white dark:bg-[#1e2235] text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
                   />
                 </>
               )}

--- a/src/components/nodes/IfNode.tsx
+++ b/src/components/nodes/IfNode.tsx
@@ -1,16 +1,11 @@
-import React, { useEffect, memo } from 'react';
+import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { WorkflowNodeData } from '../../types/workflow';
 import { FiGitBranch, FiPlus } from 'react-icons/fi';
 import { useWorkflowStore } from '../../store/workflowStore';
 
-interface IfNodeProps extends NodeProps<WorkflowNodeData> {
-  darkMode?: boolean;
-}
-
-function IfNode({ id, data, darkMode = false }: IfNodeProps) {
-  const [isDark, setIsDark] = React.useState(darkMode);
+function IfNode({ id, data }: NodeProps<WorkflowNodeData>) {
 
   const edges = useWorkflowStore((state) => state.edges);
   const draggingNodeId = useWorkflowStore((state) => state.draggingNodeId);
@@ -28,20 +23,6 @@ function IfNode({ id, data, darkMode = false }: IfNodeProps) {
     openSidebar();
   };
 
-  const colors = {
-    background: isDark ? '#1e2235' : '#fff',
-    border: isDark ? 'rgba(255,255,255,0.2)' : '#C1C1C1',
-    shadow: isDark ? '0 1px 4px rgba(0,0,0,0.5)' : '0 1px 4px rgba(0,0,0,0.1)',
-    text: isDark ? '#FFFFFF' : '#333333',
-  };
-
-  useEffect(() => {
-    if (!darkMode) {
-      const prefersDark =
-        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setIsDark(prefersDark);
-    }
-  }, [darkMode]);
 
   return (
     <div>
@@ -51,7 +32,7 @@ function IfNode({ id, data, darkMode = false }: IfNodeProps) {
         className="w-3 h-3 bg-gray-400 border-2 border-gray-600"
       />
 
-      <div className={`flex items-center p-4 shadow-lg rounded-sm border-1 bg-[${colors.background}]`}>
+      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600">
         <FiGitBranch className="w-6 h-6 text-blue-600" />
       </div>
 
@@ -63,52 +44,15 @@ function IfNode({ id, data, darkMode = false }: IfNodeProps) {
         type="source"
         id="true"
         position={Position.Right}
-        style={{
-          width: 10,
-          height: 10,
-          borderRadius: '50%',
-          border: `2px solid ${colors.border}`,
-          background: colors.background,
-          right: 0,
-          top: '35%',
-          transform: 'translate(50%, -50%)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: colors.text,
-          fontSize: 14,
-        }}
+        style={{ top: '35%' }}
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 translate-x-1/2 -translate-y-1/2 top-[35%] text-[14px]"
       >
         {showPlusTrue && (
           <>
-            <div
-              style={{
-                position: 'absolute',
-                right: -30,
-                top: '50%',
-                width: 30,
-                height: 2,
-                background: colors.border,
-                transform: 'translateY(-50%)',
-                pointerEvents: 'none',
-              }}
-            />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
             <FiPlus
               onClick={onAdd('true')}
-              style={{
-                position: 'absolute',
-                right: -45,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                width: 20,
-                height: 20,
-                border: `2px solid ${colors.border}`,
-                borderRadius: 4,
-                padding: 2,
-                background: colors.background,
-                color: colors.text,
-                cursor: 'pointer',
-              }}
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}
@@ -118,52 +62,15 @@ function IfNode({ id, data, darkMode = false }: IfNodeProps) {
         type="source"
         id="false"
         position={Position.Right}
-        style={{
-          width: 10,
-          height: 10,
-          borderRadius: '50%',
-          border: `2px solid ${colors.border}`,
-          background: colors.background,
-          right: 0,
-          top: '65%',
-          transform: 'translate(50%, -50%)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: colors.text,
-          fontSize: 14,
-        }}
+        style={{ top: '65%' }}
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 translate-x-1/2 -translate-y-1/2 top-[65%] text-[14px]"
       >
         {showPlusFalse && (
           <>
-            <div
-              style={{
-                position: 'absolute',
-                right: -30,
-                top: '50%',
-                width: 30,
-                height: 2,
-                background: colors.border,
-                transform: 'translateY(-50%)',
-                pointerEvents: 'none',
-              }}
-            />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
             <FiPlus
               onClick={onAdd('false')}
-              style={{
-                position: 'absolute',
-                right: -45,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                width: 20,
-                height: 20,
-                border: `2px solid ${colors.border}`,
-                borderRadius: 4,
-                padding: 2,
-                background: colors.background,
-                color: colors.text,
-                cursor: 'pointer',
-              }}
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}

--- a/src/components/nodes/IfNode.tsx
+++ b/src/components/nodes/IfNode.tsx
@@ -32,7 +32,7 @@ function IfNode({ id, data }: NodeProps<WorkflowNodeData>) {
         className="w-3 h-3 bg-gray-400 border-2 border-gray-600"
       />
 
-      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600">
+      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20">
         <FiGitBranch className="w-6 h-6 text-blue-600" />
       </div>
 
@@ -45,14 +45,14 @@ function IfNode({ id, data }: NodeProps<WorkflowNodeData>) {
         id="true"
         position={Position.Right}
         style={{ top: '35%' }}
-        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 translate-x-1/2 -translate-y-1/2 top-[35%] text-[14px]"
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 translate-x-1/2 -translate-y-1/2 top-[35%] text-[14px]"
       >
         {showPlusTrue && (
           <>
-            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-white/20" />
             <FiPlus
               onClick={onAdd('true')}
-              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-white/20 bg-white dark:bg-[#1e2235] text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}
@@ -63,14 +63,14 @@ function IfNode({ id, data }: NodeProps<WorkflowNodeData>) {
         id="false"
         position={Position.Right}
         style={{ top: '65%' }}
-        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 translate-x-1/2 -translate-y-1/2 top-[65%] text-[14px]"
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 translate-x-1/2 -translate-y-1/2 top-[65%] text-[14px]"
       >
         {showPlusFalse && (
           <>
-            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-white/20" />
             <FiPlus
               onClick={onAdd('false')}
-              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-white/20 bg-white dark:bg-[#1e2235] text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}

--- a/src/components/nodes/MergeNode.tsx
+++ b/src/components/nodes/MergeNode.tsx
@@ -1,16 +1,11 @@
-import React, { useEffect, memo } from 'react';
+import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { WorkflowNodeData } from '../../types/workflow';
 import { FiGitMerge, FiPlus } from 'react-icons/fi';
 import { useWorkflowStore } from '../../store/workflowStore';
 
-interface MergeNodeProps extends NodeProps<WorkflowNodeData> {
-  darkMode?: boolean;
-}
-
-function MergeNode({ id, data, darkMode = false }: MergeNodeProps) {
-  const [isDark, setIsDark] = React.useState(darkMode);
+function MergeNode({ id, data }: NodeProps<WorkflowNodeData>) {
 
   const edges = useWorkflowStore((state) => state.edges);
   const draggingNodeId = useWorkflowStore((state) => state.draggingNodeId);
@@ -23,20 +18,6 @@ function MergeNode({ id, data, darkMode = false }: MergeNodeProps) {
     setPendingConnection({ source: id, sourceHandle: 'out' });
     openSidebar();
   };
-  const colors = {
-    background: isDark ? '#1e2235' : '#fff',
-    border: isDark ? 'rgba(255,255,255,0.2)' : '#C1C1C1',
-    shadow: isDark ? '0 1px 4px rgba(0,0,0,0.5)' : '0 1px 4px rgba(0,0,0,0.1)',
-    text: isDark ? '#FFFFFF' : '#333333',
-  };
-
-  useEffect(() => {
-    if (!darkMode) {
-      const prefersDark =
-        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setIsDark(prefersDark);
-    }
-  }, [darkMode]);
 
   const inputCount = (data.inputCount as number) || 2;
   const step = 100 / (inputCount + 1);
@@ -54,7 +35,7 @@ function MergeNode({ id, data, darkMode = false }: MergeNodeProps) {
         />
       ))}
 
-      <div className={`flex items-center p-4 shadow-lg rounded-sm border-1 bg-[${colors.background}]`}>
+      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600">
         <FiGitMerge className="w-6 h-6 text-blue-600" />
       </div>
 
@@ -66,52 +47,14 @@ function MergeNode({ id, data, darkMode = false }: MergeNodeProps) {
         type="source"
         id="out"
         position={Position.Right}
-        style={{
-          width: 10,
-          height: 10,
-          borderRadius: '50%',
-          border: `2px solid ${colors.border}`,
-          background: colors.background,
-          right: 0,
-          top: '50%',
-          transform: 'translate(50%, -50%)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: colors.text,
-          fontSize: 14,
-        }}
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
       >
         {showPlus && (
           <>
-            <div
-              style={{
-                position: 'absolute',
-                right: -30,
-                top: '50%',
-                width: 30,
-                height: 2,
-                background: colors.border,
-                transform: 'translateY(-50%)',
-                pointerEvents: 'none',
-              }}
-            />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
             <FiPlus
               onClick={onAdd}
-              style={{
-                position: 'absolute',
-                right: -45,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                width: 20,
-                height: 20,
-                border: `2px solid ${colors.border}`,
-                borderRadius: 4,
-                padding: 2,
-                background: colors.background,
-                color: colors.text,
-                cursor: 'pointer',
-              }}
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}

--- a/src/components/nodes/MergeNode.tsx
+++ b/src/components/nodes/MergeNode.tsx
@@ -35,7 +35,7 @@ function MergeNode({ id, data }: NodeProps<WorkflowNodeData>) {
         />
       ))}
 
-      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600">
+      <div className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20">
         <FiGitMerge className="w-6 h-6 text-blue-600" />
       </div>
 
@@ -47,14 +47,14 @@ function MergeNode({ id, data }: NodeProps<WorkflowNodeData>) {
         type="source"
         id="out"
         position={Position.Right}
-        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
       >
         {showPlus && (
           <>
-            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-white/20" />
             <FiPlus
               onClick={onAdd}
-              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-white/20 bg-white dark:bg-[#1e2235] text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}

--- a/src/components/nodes/StyledNode.tsx
+++ b/src/components/nodes/StyledNode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, memo } from "react";
+import { memo } from "react";
 import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
 import type { WorkflowNodeData } from "../../types/workflow";
@@ -17,12 +17,7 @@ import {
 } from "react-icons/fi";
 import { useWorkflowStore } from "../../store/workflowStore";
 
-interface StyledNodeProps extends NodeProps<WorkflowNodeData> {
-  darkMode?: boolean;
-}
-
-function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
-  const [isDark, setIsDark] = React.useState(darkMode);
+function StyledNode({ id, data }: NodeProps<WorkflowNodeData>) {
 
   // Access the global edges to know if this node already has an outgoing
   // connection. The plus button is hidden whenever at least one edge starts
@@ -40,23 +35,6 @@ function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
     setPendingConnection({ source: id, sourceHandle: "out" });
     openSidebar();
   };
-  const colors = {
-    background: isDark ? "#1e2235" : "#fff",
-    border: isDark ? "rgba(255,255,255,0.2)" : "#C1C1C1",
-    shadow: isDark
-      ? "0 1px 4px rgba(0,0,0,0.5)"
-      : "0 1px 4px rgba(0,0,0,0.1)",
-    text: isDark ? "#FFFFFF" : "#333333",
-  };
-
-  useEffect(() => {
-    if (!darkMode) {
-      const prefersDark =
-        window.matchMedia &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches;
-      setIsDark(prefersDark);
-    }
-  }, [darkMode]);
 
   const IconMap = {
     httpRequest: FiGlobe,
@@ -85,7 +63,7 @@ function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
       />
 
       <div
-        className={`flex items-center p-4 shadow-lg rounded-sm border-1 bg-[${colors.background}]`}
+        className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
       >
         <Icon className="w-6 h-6 text-blue-600" />
       </div>
@@ -105,52 +83,16 @@ function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
         type="source"
         id="out"
         position={Position.Right}
-        style={{
-          width: 10,
-          height: 10,
-          borderRadius: "50%",
-          border: `2px solid ${colors.border}`,
-          background: colors.background,
-          right: 0,
-          top: "50%",
-          transform: "translate(50%, -50%)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: colors.text,
-          fontSize: 14,
-        }}
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
       >
         {showPlus && (
           <>
             <div
-              style={{
-                position: "absolute",
-                right: -30,
-                top: "50%",
-                width: 30,
-                height: 2,
-                background: colors.border,
-                transform: "translateY(-50%)",
-                pointerEvents: "none",
-              }}
+              className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600"
             />
             <FiPlus
               onClick={onAdd}
-              style={{
-                position: "absolute",
-                right: -45,
-                top: "50%",
-                transform: "translateY(-50%)",
-                width: 20,
-                height: 20,
-                border: `2px solid ${colors.border}`,
-                borderRadius: 4,
-                padding: 2,
-                background: colors.background,
-                color: colors.text,
-                cursor: "pointer",
-              }}
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}

--- a/src/components/nodes/StyledNode.tsx
+++ b/src/components/nodes/StyledNode.tsx
@@ -63,7 +63,7 @@ function StyledNode({ id, data }: NodeProps<WorkflowNodeData>) {
       />
 
       <div
-        className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600"
+        className="flex items-center p-4 shadow-lg rounded-sm border bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20"
       >
         <Icon className="w-6 h-6 text-blue-600" />
       </div>
@@ -83,16 +83,16 @@ function StyledNode({ id, data }: NodeProps<WorkflowNodeData>) {
         type="source"
         id="out"
         position={Position.Right}
-        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
       >
         {showPlus && (
           <>
             <div
-              className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600"
+              className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-white/20"
             />
             <FiPlus
               onClick={onAdd}
-              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-white/20 bg-white dark:bg-[#1e2235] text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}

--- a/src/components/nodes/WebhookNode.tsx
+++ b/src/components/nodes/WebhookNode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, memo } from "react";
+import { memo } from "react";
 import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
 import { FiLink, FiPlus, FiZap } from "react-icons/fi";
@@ -6,17 +6,8 @@ import type { WorkflowNodeData } from "../../types/workflow";
 import { useWorkflowStore } from "../../store/workflowStore";
 
 function WebhookNode({ id, data }: NodeProps<WorkflowNodeData>) {
-  const [darkMode, setDarkMode] = React.useState(false);
   const isListening = (data as { isListening?: boolean })?.isListening;
 
-  const colors = {
-    background: darkMode ? "#1e2235" : "#fff",
-    border: darkMode ? "rgba(255,255,255,0.2)" : "#C1C1C1",
-    shadow: darkMode
-      ? "0 1px 4px rgba(0,0,0,0.5)"
-      : "0 1px 4px rgba(0,0,0,0.1)",
-    text: darkMode ? "#FFFFFF" : "#333333",
-  };
 
   const edges = useWorkflowStore((state) => state.edges);
   const draggingNodeId = useWorkflowStore((state) => state.draggingNodeId);
@@ -32,17 +23,11 @@ function WebhookNode({ id, data }: NodeProps<WorkflowNodeData>) {
     openSidebar();
   };
 
-  useEffect(() => {
-    const prefersDark =
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches;
-    setDarkMode(prefersDark);
-  }, []);
 
   return (
     <div>
       <div
-        className={`flex items-center p-4 shadow-lg border-1 bg-[${colors.background}] rounded-r-sm rounded-l-3xl`}
+        className="flex items-center p-4 shadow-lg border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 rounded-r-sm rounded-l-3xl"
       >
         <FiLink className="w-6 h-6 text-blue-600" />
         {isListening && (
@@ -57,52 +42,14 @@ function WebhookNode({ id, data }: NodeProps<WorkflowNodeData>) {
         type="source"
         id="out"
         position={Position.Right}
-        style={{
-          width: 10,
-          height: 10,
-          borderRadius: "50%",
-          border: `2px solid ${colors.border}`,
-          background: colors.background,
-          right: 0,
-          top: "50%",
-          transform: "translate(50%, -50%)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: colors.text,
-          fontSize: 14,
-        }}
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
       >
         {showPlus && (
           <>
-            <div
-              style={{
-                position: "absolute",
-                right: -30,
-                top: "50%",
-                width: 30,
-                height: 2,
-                background: colors.border,
-                transform: "translateY(-50%)",
-                pointerEvents: "none",
-              }}
-            />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
             <FiPlus
               onClick={onAdd}
-              style={{
-                position: "absolute",
-                right: -45,
-                top: "50%",
-                transform: "translateY(-50%)",
-                width: 20,
-                height: 20,
-                border: `2px solid ${colors.border}`,
-                borderRadius: 4,
-                padding: 2,
-                background: colors.background,
-                color: colors.text,
-                cursor: "pointer",
-              }}
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}

--- a/src/components/nodes/WebhookNode.tsx
+++ b/src/components/nodes/WebhookNode.tsx
@@ -27,7 +27,7 @@ function WebhookNode({ id, data }: NodeProps<WorkflowNodeData>) {
   return (
     <div>
       <div
-        className="flex items-center p-4 shadow-lg border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 rounded-r-sm rounded-l-3xl"
+        className="flex items-center p-4 shadow-lg border bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 rounded-r-sm rounded-l-3xl"
       >
         <FiLink className="w-6 h-6 text-blue-600" />
         {isListening && (
@@ -42,14 +42,14 @@ function WebhookNode({ id, data }: NodeProps<WorkflowNodeData>) {
         type="source"
         id="out"
         position={Position.Right}
-        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
+        className="w-2.5 h-2.5 rounded-full border-2 bg-white dark:bg-[#1e2235] border-gray-300 dark:border-white/20 text-gray-800 dark:text-gray-100 flex items-center justify-center absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 text-[14px]"
       >
         {showPlus && (
           <>
-            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-gray-600" />
+            <div className="absolute right-[30px] top-1/2 w-[30px] h-[2px] -translate-y-1/2 pointer-events-none bg-gray-300 dark:bg-white/20" />
             <FiPlus
               onClick={onAdd}
-              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
+              className="absolute right-[45px] top-1/2 -translate-y-1/2 w-5 h-5 border-2 border-gray-300 dark:border-white/20 bg-white dark:bg-[#1e2235] text-gray-800 dark:text-gray-100 rounded p-[2px] cursor-pointer"
             />
           </>
         )}


### PR DESCRIPTION
## Summary
- replace inline dark-mode styles in node components with Tailwind classes
- clean up ButtonEdge dark mode logic

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_684bc2be8ad08320b46159f98d59ce43