### PR TITLE
Fix workflow save/load

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -15,9 +15,10 @@ export function Toolbar() {
   }, [clearWorkflow]);
 
   const handleSave = useCallback(() => {
+    const cleanEdges = edges.map(({ data, ...rest }) => ({ ...rest, data: {} }));
     const workflow = {
       nodes,
-      edges,
+      edges: cleanEdges,
     };
     const blob = new Blob([JSON.stringify(workflow, null, 2)], {
       type: 'application/json',

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -44,10 +44,9 @@ export function Toolbar() {
           try {
             const workflow = JSON.parse(event.target?.result as string);
             // TODO: Validate workflow structure
-            useWorkflowStore.setState({
-              nodes: workflow.nodes,
-              edges: workflow.edges,
-            });
+            const { setNodes, setEdges } = useWorkflowStore.getState();
+            setNodes(workflow.nodes);
+            setEdges(workflow.edges);
           } catch {
             alert('Invalid workflow file');
           }

--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -130,6 +130,7 @@ export function WorkflowEditor() {
     setNodes: setStoreNodes,
     addNode,
     addEdge: addStoreEdge,
+    updateNode,
     deleteEdge,
     pendingConnection,
     setPendingConnection,
@@ -144,6 +145,15 @@ export function WorkflowEditor() {
     useNodesState<WorkflowNodeData>(initialNodes);
   const [edges, setEdges, onEdgesChange] =
     useEdgesState<WorkflowEdgeData>(initialEdges);
+
+  // Keep local state in sync with the store
+  useEffect(() => {
+    setNodes(initialNodes);
+  }, [initialNodes, setNodes]);
+
+  useEffect(() => {
+    setEdges(initialEdges);
+  }, [initialEdges, setEdges]);
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const reactFlowInstance = useRef<ReactFlowInstance | null>(null);
   const connectStart = useRef<OnConnectStartParams | null>(null);
@@ -185,8 +195,17 @@ export function WorkflowEditor() {
           return node;
         })
       );
+
+      const storeNode = useWorkflowStore
+        .getState()
+        .nodes.find((n) => n.id === nodeId);
+      if (storeNode) {
+        updateNode(nodeId, {
+          data: { ...storeNode.data, ...newData },
+        });
+      }
     },
-    [setNodes]
+    [setNodes, updateNode]
   );
 
   useEffect(() => {

--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -152,8 +152,21 @@ export function WorkflowEditor() {
   }, [initialNodes, setNodes]);
 
   useEffect(() => {
-    setEdges(initialEdges);
-  }, [initialEdges, setEdges]);
+    const hydratedEdges = initialEdges.map((e) => ({
+      ...e,
+      data: {
+        onAddEdgeClick: () => {
+          setPendingConnection({
+            source: e.source,
+            sourceHandle: e.sourceHandle ?? null,
+          });
+          openSidebar();
+        },
+        onDeleteEdgeClick: () => handleEdgeDelete(e.id),
+      },
+    }));
+    setEdges(hydratedEdges);
+  }, [initialEdges, setEdges, setPendingConnection, openSidebar, handleEdgeDelete]);
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const reactFlowInstance = useRef<ReactFlowInstance | null>(null);
   const connectStart = useRef<OnConnectStartParams | null>(null);
@@ -270,7 +283,7 @@ export function WorkflowEditor() {
         // both handles occupied, don't auto connect
       } else {
         setEdges((eds) => addEdge(newEdge, eds));
-        addStoreEdge(newEdge);
+        addStoreEdge({ ...newEdge, data: {} });
       }
     }
 
@@ -312,7 +325,7 @@ export function WorkflowEditor() {
         },
       };
       setEdges((eds) => addEdge(newEdge, eds));
-      addStoreEdge(newEdge);
+      addStoreEdge({ ...newEdge, data: {} });
       setDraggingNodeId(null);
     },
     [
@@ -422,7 +435,7 @@ export function WorkflowEditor() {
             },
           };
           setEdges((eds) => addEdge(newEdge, eds));
-          addStoreEdge(newEdge);
+          addStoreEdge({ ...newEdge, data: {} });
         }
         setPendingConnection(null);
       }


### PR DESCRIPTION
## Summary
- fix save/load by updating store when saving nodes
- keep workflow editor in sync with store

## Testing
- `yarn lint`
- `yarn build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bc8ad36288320bbadc0b998540f2b