### PR TITLE
Add node description editing

### DIFF
--- a/src/components/AirtableSettings.tsx
+++ b/src/components/AirtableSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface AirtableSettingsProps {
   data: Record<string, unknown>;

--- a/src/components/CodeSettings.tsx
+++ b/src/components/CodeSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface CodeSettingsProps {
   data: Record<string, unknown>;

--- a/src/components/DelaySettings.tsx
+++ b/src/components/DelaySettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface DelaySettingsProps {
   data: Record<string, unknown>;

--- a/src/components/EmailSettings.tsx
+++ b/src/components/EmailSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface EmailSettingsProps {
   data: Record<string, unknown>;

--- a/src/components/HttpRequestSettings.tsx
+++ b/src/components/HttpRequestSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 
 interface HttpRequestSettingsProps {
   data: Record<string, unknown>;
@@ -6,7 +6,7 @@ interface HttpRequestSettingsProps {
 }
 
 export default function HttpRequestSettings({ data, onChange }: HttpRequestSettingsProps) {
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const reader = new FileReader();
@@ -69,7 +69,7 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
           className="w-full px-3 py-2 border border-gray-600 rounded-md"
           value={undefined}
         />
-        {data.fileName && (
+        {!!data.fileName && (
           <div className="mt-2 text-xs text-gray-700">Selected file: {data.fileName as string}</div>
         )}
       </div>

--- a/src/components/IfSettings.tsx
+++ b/src/components/IfSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface IfSettingsProps {
   data: Record<string, unknown>;

--- a/src/components/MergeSettings.tsx
+++ b/src/components/MergeSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface MergeSettingsProps {
   data: Record<string, unknown>;

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { FiSettings, FiX } from "react-icons/fi";
 import type { Node } from "reactflow";
 import WebhookSettings from "./WebhookSettings";
@@ -22,6 +22,24 @@ export default function PropertiesPanel({
   onClose,
 }: PropertiesPanelProps) {
   const [formData, setFormData] = useState(node.data);
+
+  const handleLabelChange = (value: string) => {
+    const newData = { ...formData, label: value };
+    setFormData(newData);
+    onUpdateNode(node.id, {
+      label: value,
+      description: (newData as { description?: string }).description ?? "",
+    });
+  };
+
+  const handleDescriptionChange = (value: string) => {
+    const newData = { ...formData, description: value };
+    setFormData(newData);
+    onUpdateNode(node.id, {
+      label: (newData as { label?: string }).label ?? "",
+      description: value,
+    });
+  };
 
   useEffect(() => {
     setFormData(node.data);
@@ -286,6 +304,30 @@ export default function PropertiesPanel({
           <FiX className="w-5 h-5" />
           {/* <span className="hidden md:inline">Close</span> */}
         </button>
+      </div>
+      <div className="p-4 space-y-2 border-b border-gray-200 bg-white">
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-1">
+            Label
+          </label>
+          <input
+            type="text"
+            value={formData.label || ""}
+            onChange={(e) => handleLabelChange(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-1">
+            Description
+          </label>
+          <input
+            type="text"
+            value={(formData as { description?: string }).description || ""}
+            onChange={(e) => handleDescriptionChange(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
       </div>
       {/* Tabs */}
       <div className="flex border-b border-gray-200 bg-white">

--- a/src/components/SetSettings.tsx
+++ b/src/components/SetSettings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 interface SetSettingsProps {
   data: Record<string, unknown>;

--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -223,6 +223,7 @@ export function WorkflowEditor() {
       position,
       data: {
         label: nodeToAdd.charAt(0).toUpperCase() + nodeToAdd.slice(1),
+        description: "",
         config: {},
         type: nodeToAdd,
         ...defaults,
@@ -396,6 +397,7 @@ export function WorkflowEditor() {
         position,
         data: {
           label: type.charAt(0).toUpperCase() + type.slice(1),
+          description: "",
           config: {},
           type,
           ...defaults,

--- a/src/components/nodes/HttpRequestNode.tsx
+++ b/src/components/nodes/HttpRequestNode.tsx
@@ -85,6 +85,11 @@ export default function HttpRequestNode({ id, data, selected}: NodeProps) {
       </div>
       <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+4px)] text-center w-full">
           <div className="font-medium text-[8px]">HTTP Request</div>
+          {data.description && (
+            <div className="text-[6px] text-gray-500 whitespace-pre-wrap">
+              {data.description}
+            </div>
+          )}
           <div className="flex justify-center">
             <span className={`text-[6px]`}>
               {method}:&nbsp;

--- a/src/components/nodes/IfNode.tsx
+++ b/src/components/nodes/IfNode.tsx
@@ -84,6 +84,11 @@ function IfNode({ id, data, darkMode = false }: IfNodeProps) {
 
       <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
         <div className="font-medium text-[8px]">{data.label}</div>
+        {data.description && (
+          <div className="text-[6px] text-gray-500 whitespace-pre-wrap">
+            {data.description}
+          </div>
+        )}
       </div>
 
       <Handle

--- a/src/components/nodes/MergeNode.tsx
+++ b/src/components/nodes/MergeNode.tsx
@@ -86,6 +86,11 @@ function MergeNode({ id, data, darkMode = false }: MergeNodeProps) {
 
       <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
         <div className="font-medium text-[8px]">{data.label}</div>
+        {data.description && (
+          <div className="text-[6px] text-gray-500 whitespace-pre-wrap">
+            {data.description}
+          </div>
+        )}
       </div>
 
       <Handle

--- a/src/components/nodes/StyledNode.tsx
+++ b/src/components/nodes/StyledNode.tsx
@@ -121,6 +121,11 @@ function StyledNode({ id, data, darkMode = false }: StyledNodeProps) {
 
       <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
         <div className="font-medium text-[8px]">{data.label}</div>
+        {data.description && (
+          <div className="text-[6px] text-gray-500 whitespace-pre-wrap">
+            {data.description}
+          </div>
+        )}
       </div>
 
       {/*

--- a/src/components/nodes/WebhookNode.tsx
+++ b/src/components/nodes/WebhookNode.tsx
@@ -81,6 +81,11 @@ function WebhookNode({ id, data }: NodeProps<WorkflowNodeData>) {
       </div>
       <div className="flex-1 absolute bottom-0 translate-y-[calc(100%+2px)] text-center w-full">
         <div className="font-medium text-[8px]">Webhook</div>
+        {data.description && (
+          <div className="text-[6px] text-gray-500 whitespace-pre-wrap">
+            {data.description}
+          </div>
+        )}
       </div>
 
       <Handle

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -17,6 +17,7 @@ export type NodeType =
 
 export interface WorkflowNodeData {
   label: string;
+  description?: string;
   config: Record<string, unknown>;
   type: NodeType;
 }


### PR DESCRIPTION
## Summary
- allow editing node label and description in the properties panel
- keep label/description in workflow state
- show the description below nodes on the canvas
- fix TypeScript errors in settings components

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6853b4338a2c83208fe3845f3f2f87ed