### PR TITLE
Add fieldsets and tooltips to settings

### DIFF
--- a/src/components/AirtableSettings.tsx
+++ b/src/components/AirtableSettings.tsx
@@ -1,4 +1,6 @@
 
+import { FiInfo } from 'react-icons/fi';
+
 interface AirtableSettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -7,63 +9,92 @@ interface AirtableSettingsProps {
 export default function AirtableSettings({ data, onChange }: AirtableSettingsProps) {
   return (
     <div className="space-y-4 text-left">
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">API Key</label>
-        <input
-          type="text"
-          value={(data.apiKey as string) || ''}
-          onChange={(e) => onChange('apiKey', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Base ID</label>
-        <input
-          type="text"
-          value={(data.baseId as string) || ''}
-          onChange={(e) => onChange('baseId', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Table</label>
-        <input
-          type="text"
-          value={(data.table as string) || ''}
-          onChange={(e) => onChange('table', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Operation</label>
-        <select
-          value={(data.operation as string) || 'select'}
-          onChange={(e) => onChange('operation', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        >
-          <option value="select">Select</option>
-          <option value="create">Create</option>
-          <option value="update">Update</option>
-          <option value="delete">Delete</option>
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Fields (JSON)</label>
-        <textarea
-          value={(data.fields as string) || ''}
-          onChange={(e) => onChange('fields', e.target.value)}
-          className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Filter Formula</label>
-        <input
-          type="text"
-          value={(data.filter as string) || ''}
-          onChange={(e) => onChange('filter', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Authentication</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            API Key
+            <FiInfo className="inline-block ml-1" title="Your Airtable API key" />
+          </label>
+          <input
+            type="text"
+            value={(data.apiKey as string) || ''}
+            onChange={(e) => onChange('apiKey', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Table</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Base ID
+            <FiInfo className="inline-block ml-1" title="Airtable base identifier" />
+          </label>
+          <input
+            type="text"
+            value={(data.baseId as string) || ''}
+            onChange={(e) => onChange('baseId', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Table
+            <FiInfo className="inline-block ml-1" title="Table name" />
+          </label>
+          <input
+            type="text"
+            value={(data.table as string) || ''}
+            onChange={(e) => onChange('table', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Operation</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Operation
+            <FiInfo className="inline-block ml-1" title="Action to perform" />
+          </label>
+          <select
+            value={(data.operation as string) || 'select'}
+            onChange={(e) => onChange('operation', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          >
+            <option value="select">Select</option>
+            <option value="create">Create</option>
+            <option value="update">Update</option>
+            <option value="delete">Delete</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Fields (JSON)
+            <FiInfo className="inline-block ml-1" title="Fields payload" />
+          </label>
+          <textarea
+            value={(data.fields as string) || ''}
+            onChange={(e) => onChange('fields', e.target.value)}
+            className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Filter Formula
+            <FiInfo className="inline-block ml-1" title="Airtable filter formula" />
+          </label>
+          <input
+            type="text"
+            value={(data.filter as string) || ''}
+            onChange={(e) => onChange('filter', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/CodeSettings.tsx
+++ b/src/components/CodeSettings.tsx
@@ -1,4 +1,6 @@
 
+import { FiInfo } from 'react-icons/fi';
+
 interface CodeSettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -7,37 +9,53 @@ interface CodeSettingsProps {
 export default function CodeSettings({ data, onChange }: CodeSettingsProps) {
   return (
     <div className="space-y-4 text-left">
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Language</label>
-        <select
-          value={(data.language as string) || 'javascript'}
-          onChange={(e) => onChange('language', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        >
-          <option value="javascript">JavaScript</option>
-          <option value="typescript">TypeScript</option>
-          <option value="python">Python</option>
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Mode</label>
-        <select
-          value={(data.mode as string) || 'full'}
-          onChange={(e) => onChange('mode', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        >
-          <option value="full">Full</option>
-          <option value="inline">Inline</option>
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Code</label>
-        <textarea
-          value={(data.code as string) || ''}
-          onChange={(e) => onChange('code', e.target.value)}
-          className="w-full h-32 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
-        />
-      </div>
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Configuration</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Language
+            <FiInfo className="inline-block ml-1" title="Execution language" />
+          </label>
+          <select
+            value={(data.language as string) || 'javascript'}
+            onChange={(e) => onChange('language', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          >
+            <option value="javascript">JavaScript</option>
+            <option value="typescript">TypeScript</option>
+            <option value="python">Python</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Mode
+            <FiInfo className="inline-block ml-1" title="How the code runs" />
+          </label>
+          <select
+            value={(data.mode as string) || 'full'}
+            onChange={(e) => onChange('mode', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          >
+            <option value="full">Full</option>
+            <option value="inline">Inline</option>
+          </select>
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Body</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Code
+            <FiInfo className="inline-block ml-1" title="Script content" />
+          </label>
+          <textarea
+            value={(data.code as string) || ''}
+            onChange={(e) => onChange('code', e.target.value)}
+            className="w-full h-32 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
+          />
+        </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/DelaySettings.tsx
+++ b/src/components/DelaySettings.tsx
@@ -1,4 +1,6 @@
 
+import { FiInfo } from 'react-icons/fi';
+
 interface DelaySettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -7,24 +9,33 @@ interface DelaySettingsProps {
 export default function DelaySettings({ data, onChange }: DelaySettingsProps) {
   return (
     <div className="space-y-4 text-left">
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Duration (ms)</label>
-        <input
-          type="number"
-          value={(data.duration as number | undefined) ?? ''}
-          onChange={(e) => onChange('duration', Number(e.target.value))}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Until</label>
-        <input
-          type="datetime-local"
-          value={(data.until as string) || ''}
-          onChange={(e) => onChange('until', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Timing</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Duration (ms)
+            <FiInfo className="inline-block ml-1" title="Delay duration" />
+          </label>
+          <input
+            type="number"
+            value={(data.duration as number | undefined) ?? ''}
+            onChange={(e) => onChange('duration', Number(e.target.value))}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Until
+            <FiInfo className="inline-block ml-1" title="Delay until specific time" />
+          </label>
+          <input
+            type="datetime-local"
+            value={(data.until as string) || ''}
+            onChange={(e) => onChange('until', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/EmailSettings.tsx
+++ b/src/components/EmailSettings.tsx
@@ -1,4 +1,6 @@
 
+import { FiInfo } from 'react-icons/fi';
+
 interface EmailSettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -7,96 +9,134 @@ interface EmailSettingsProps {
 export default function EmailSettings({ data, onChange }: EmailSettingsProps) {
   return (
     <div className="space-y-4 text-left">
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">SMTP Host</label>
-        <input
-          type="text"
-          value={(data.smtpHost as string) || ''}
-          onChange={(e) => onChange('smtpHost', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div className="grid grid-cols-2 gap-2">
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Server</legend>
         <div>
-          <label className="block text-sm font-medium text-gray-600 mb-2">Port</label>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            SMTP Host
+            <FiInfo className="inline-block ml-1" title="Mail server host" />
+          </label>
           <input
-            type="number"
-            value={(data.smtpPort as number | undefined) ?? ''}
-            onChange={(e) => onChange('smtpPort', Number(e.target.value))}
+            type="text"
+            value={(data.smtpHost as string) || ''}
+            onChange={(e) => onChange('smtpHost', e.target.value)}
             className="w-full px-3 py-2 border border-gray-600 rounded-md"
           />
         </div>
-        <div className="flex items-center gap-2 mt-6">
-          <input
-            type="checkbox"
-            checked={Boolean(data.smtpSecure)}
-            onChange={(e) => onChange('smtpSecure', e.target.checked)}
-          />
-          <span className="text-sm">Secure</span>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <label className="block text-sm font-medium text-gray-600 mb-2">
+              Port
+              <FiInfo className="inline-block ml-1" title="SMTP port" />
+            </label>
+            <input
+              type="number"
+              value={(data.smtpPort as number | undefined) ?? ''}
+              onChange={(e) => onChange('smtpPort', Number(e.target.value))}
+              className="w-full px-3 py-2 border border-gray-600 rounded-md"
+            />
+          </div>
+          <div className="flex items-center gap-2 mt-6">
+            <input
+              type="checkbox"
+              checked={Boolean(data.smtpSecure)}
+              onChange={(e) => onChange('smtpSecure', e.target.checked)}
+            />
+            <span className="text-sm">Secure</span>
+          </div>
         </div>
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Username</label>
-        <input
-          type="text"
-          value={(data.smtpUser as string) || ''}
-          onChange={(e) => onChange('smtpUser', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Password</label>
-        <input
-          type="password"
-          value={(data.smtpPass as string) || ''}
-          onChange={(e) => onChange('smtpPass', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">From</label>
-        <input
-          type="text"
-          value={(data.from as string) || ''}
-          onChange={(e) => onChange('from', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">To</label>
-        <input
-          type="text"
-          value={(data.to as string) || ''}
-          onChange={(e) => onChange('to', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Subject</label>
-        <input
-          type="text"
-          value={(data.subject as string) || ''}
-          onChange={(e) => onChange('subject', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Body</label>
-        <textarea
-          value={(data.body as string) || ''}
-          onChange={(e) => onChange('body', e.target.value)}
-          className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Attachments (comma separated URLs)</label>
-        <input
-          type="text"
-          value={(data.attachments as string) || ''}
-          onChange={(e) => onChange('attachments', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Authentication</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Username
+            <FiInfo className="inline-block ml-1" title="SMTP account" />
+          </label>
+          <input
+            type="text"
+            value={(data.smtpUser as string) || ''}
+            onChange={(e) => onChange('smtpUser', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Password
+            <FiInfo className="inline-block ml-1" title="SMTP password" />
+          </label>
+          <input
+            type="password"
+            value={(data.smtpPass as string) || ''}
+            onChange={(e) => onChange('smtpPass', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Message</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            From
+            <FiInfo className="inline-block ml-1" title="Sender" />
+          </label>
+          <input
+            type="text"
+            value={(data.from as string) || ''}
+            onChange={(e) => onChange('from', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            To
+            <FiInfo className="inline-block ml-1" title="Recipient" />
+          </label>
+          <input
+            type="text"
+            value={(data.to as string) || ''}
+            onChange={(e) => onChange('to', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Subject
+            <FiInfo className="inline-block ml-1" title="Email subject" />
+          </label>
+          <input
+            type="text"
+            value={(data.subject as string) || ''}
+            onChange={(e) => onChange('subject', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Body
+            <FiInfo className="inline-block ml-1" title="Email body" />
+          </label>
+          <textarea
+            value={(data.body as string) || ''}
+            onChange={(e) => onChange('body', e.target.value)}
+            className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Attachments (comma separated URLs)
+            <FiInfo className="inline-block ml-1" title="Attachment links" />
+          </label>
+          <input
+            type="text"
+            value={(data.attachments as string) || ''}
+            onChange={(e) => onChange('attachments', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/HttpRequestSettings.tsx
+++ b/src/components/HttpRequestSettings.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent } from 'react';
+import { FiInfo } from 'react-icons/fi';
 
 interface HttpRequestSettingsProps {
   data: Record<string, unknown>;
@@ -21,58 +22,84 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
 
   return (
     <div className="space-y-4 text-left">
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Method</label>
-        <select
-          value={(data.method as string) || 'GET'}
-          onChange={(e) => onChange('method', e.target.value)}
-          className="w-full px-3 py-2  border border-gray-600 rounded-md"
-        >
-          {['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].map((m) => (
-            <option key={m} value={m}>{m}</option>
-          ))}
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">URL</label>
-        <input
-          type="text"
-          value={(data.url as string) || ''}
-          onChange={(e) => onChange('url', e.target.value)}
-          placeholder="https://api.example.com/endpoint"
-          className="w-full px-3 py-2  border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Headers (JSON)</label>
-        <textarea
-          value={(data.headers as string) || ''}
-          onChange={(e) => onChange('headers', e.target.value)}
-          placeholder='{"Content-Type": "application/json"}'
-          className="w-full h-24 px-3 py-2  border border-gray-600 rounded-md  font-mono text-sm"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Body</label>
-        <textarea
-          value={(data.body as string) || ''}
-          onChange={(e) => onChange('body', e.target.value)}
-          placeholder="{name: 'John Doe'}"
-          className="w-full h-32 px-3 py-2  border border-gray-600 rounded-md font-mono text-sm"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">File Upload (optional)</label>
-        <input
-          type="file"
-          onChange={handleFileChange}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-          value={undefined}
-        />
-        {!!data.fileName && (
-          <div className="mt-2 text-xs text-gray-700">Selected file: {data.fileName as string}</div>
-        )}
-      </div>
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Request</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Method
+            <FiInfo className="inline-block ml-1" title="HTTP method" />
+          </label>
+          <select
+            value={(data.method as string) || 'GET'}
+            onChange={(e) => onChange('method', e.target.value)}
+            className="w-full px-3 py-2  border border-gray-600 rounded-md"
+          >
+            {['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            URL
+            <FiInfo className="inline-block ml-1" title="Request endpoint" />
+          </label>
+          <input
+            type="text"
+            value={(data.url as string) || ''}
+            onChange={(e) => onChange('url', e.target.value)}
+            placeholder="https://api.example.com/endpoint"
+            className="w-full px-3 py-2  border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Headers</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Headers (JSON)
+            <FiInfo className="inline-block ml-1" title="Additional request headers" />
+          </label>
+          <textarea
+            value={(data.headers as string) || ''}
+            onChange={(e) => onChange('headers', e.target.value)}
+            placeholder='{"Content-Type": "application/json"}'
+            className="w-full h-24 px-3 py-2  border border-gray-600 rounded-md  font-mono text-sm"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Body</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Body
+            <FiInfo className="inline-block ml-1" title="Request payload" />
+          </label>
+          <textarea
+            value={(data.body as string) || ''}
+            onChange={(e) => onChange('body', e.target.value)}
+            placeholder="{name: 'John Doe'}"
+            className="w-full h-32 px-3 py-2  border border-gray-600 rounded-md font-mono text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            File Upload (optional)
+            <FiInfo className="inline-block ml-1" title="Binary payload" />
+          </label>
+          <input
+            type="file"
+            onChange={handleFileChange}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+            value={undefined}
+          />
+          {!!data.fileName && (
+            <div className="mt-2 text-xs text-gray-700">Selected file: {data.fileName as string}</div>
+          )}
+        </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/IfSettings.tsx
+++ b/src/components/IfSettings.tsx
@@ -1,4 +1,6 @@
 
+import { FiInfo } from 'react-icons/fi';
+
 interface IfSettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -22,62 +24,72 @@ export default function IfSettings({ data, onChange }: IfSettingsProps) {
   };
 
   return (
-    <div className="space-y-2 text-left overflow-x-hidden">
-      {conditions.map((c, idx) => (
-        <div key={idx} className="flex flex-wrap items-center gap-2 min-w-0">
-          <input
-            type="text"
-            value={c.left}
-            onChange={(e) => handleConditionChange(idx, 'left', e.target.value)}
-            placeholder="Field"
-            className="flex-1 min-w-0 px-2 py-1 border border-gray-600 rounded-md"
-          />
+    <div className="space-y-4 text-left overflow-x-hidden">
+      <fieldset className="space-y-2">
+        <legend className="font-medium">Conditions</legend>
+        {conditions.map((c, idx) => (
+          <div key={idx} className="flex flex-wrap items-center gap-2 min-w-0">
+            <input
+              type="text"
+              value={c.left}
+              onChange={(e) => handleConditionChange(idx, 'left', e.target.value)}
+              placeholder="Field"
+              className="flex-1 min-w-0 px-2 py-1 border border-gray-600 rounded-md"
+            />
+            <select
+              value={c.op}
+              onChange={(e) => handleConditionChange(idx, 'op', e.target.value)}
+              className="px-2 py-1 border border-gray-600 rounded-md"
+              style={{ maxWidth: 150 }}
+            >
+              <option value="==">equals</option>
+              <option value="!=">not equals</option>
+              <option value=">">greater than</option>
+              <option value=">=">greater than or equal</option>
+              <option value="<">less than</option>
+              <option value="<=">less than or equal</option>
+              <option value="contains">contains</option>
+              <option value="not_contains">not contains</option>
+              <option value="starts_with">starts with</option>
+              <option value="ends_with">ends with</option>
+            </select>
+            <input
+              type="text"
+              value={c.right}
+              onChange={(e) => handleConditionChange(idx, 'right', e.target.value)}
+              placeholder="Value"
+              className="flex-1 min-w-0 px-2 py-1 border border-gray-600 rounded-md"
+            />
+            <button
+              onClick={() => removeCondition(idx)}
+              className="px-2 py-1 text-xs bg-red-500 text-white rounded"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button onClick={addCondition} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">
+          Add Condition
+        </button>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="font-medium">Match</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-1">
+            Match
+            <FiInfo className="inline-block ml-1" title="Condition join type" />
+          </label>
           <select
-            value={c.op}
-            onChange={(e) => handleConditionChange(idx, 'op', e.target.value)}
-            className="px-2 py-1 border border-gray-600 rounded-md"
-            style={{ maxWidth: 150 }}
+            value={(data.andOr as string) || 'AND'}
+            onChange={(e) => onChange('andOr', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
           >
-            <option value="==">equals</option>
-            <option value="!=">not equals</option>
-            <option value=">">greater than</option>
-            <option value=">=">greater than or equal</option>
-            <option value="<">less than</option>
-            <option value="<=">less than or equal</option>
-            <option value="contains">contains</option>
-            <option value="not_contains">not contains</option>
-            <option value="starts_with">starts with</option>
-            <option value="ends_with">ends with</option>
+            <option value="AND">AND</option>
+            <option value="OR">OR</option>
           </select>
-          <input
-            type="text"
-            value={c.right}
-            onChange={(e) => handleConditionChange(idx, 'right', e.target.value)}
-            placeholder="Value"
-            className="flex-1 min-w-0 px-2 py-1 border border-gray-600 rounded-md"
-          />
-          <button
-            onClick={() => removeCondition(idx)}
-            className="px-2 py-1 text-xs bg-red-500 text-white rounded"
-          >
-            Remove
-          </button>
         </div>
-      ))}
-      <button onClick={addCondition} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">
-        Add Condition
-      </button>
-      <div className="mt-2">
-        <label className="block text-sm font-medium text-gray-600 mb-1">Match</label>
-        <select
-          value={(data.andOr as string) || 'AND'}
-          onChange={(e) => onChange('andOr', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        >
-          <option value="AND">AND</option>
-          <option value="OR">OR</option>
-        </select>
-      </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/MergeSettings.tsx
+++ b/src/components/MergeSettings.tsx
@@ -1,4 +1,6 @@
 
+import { FiInfo } from 'react-icons/fi';
+
 interface MergeSettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -7,38 +9,54 @@ interface MergeSettingsProps {
 export default function MergeSettings({ data, onChange }: MergeSettingsProps) {
   return (
     <div className="space-y-4 text-left">
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Mode</label>
-        <select
-          value={(data.mergeMode as string) || 'append'}
-          onChange={(e) => onChange('mergeMode', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        >
-          <option value="append">Append</option>
-          <option value="combine">Combine</option>
-          <option value="overwrite">Overwrite</option>
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Fields</label>
-        <input
-          type="text"
-          value={(data.mergeFields as string) || ''}
-          onChange={(e) => onChange('mergeFields', e.target.value)}
-          placeholder="Comma separated fields"
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-gray-600 mb-2">Inputs</label>
-        <input
-          type="number"
-          min={1}
-          value={(data.inputCount as number) || 2}
-          onChange={(e) => onChange('inputCount', parseInt(e.target.value, 10) || 1)}
-          className="w-full px-3 py-2 border border-gray-600 rounded-md"
-        />
-      </div>
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Merge Options</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Mode
+            <FiInfo className="inline-block ml-1" title="How inputs are merged" />
+          </label>
+          <select
+            value={(data.mergeMode as string) || 'append'}
+            onChange={(e) => onChange('mergeMode', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          >
+            <option value="append">Append</option>
+            <option value="combine">Combine</option>
+            <option value="overwrite">Overwrite</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Fields
+            <FiInfo className="inline-block ml-1" title="Fields to merge" />
+          </label>
+          <input
+            type="text"
+            value={(data.mergeFields as string) || ''}
+            onChange={(e) => onChange('mergeFields', e.target.value)}
+            placeholder="Comma separated fields"
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="font-medium">Input</legend>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-2">
+            Inputs
+            <FiInfo className="inline-block ml-1" title="Number of inputs" />
+          </label>
+          <input
+            type="number"
+            min={1}
+            value={(data.inputCount as number) || 2}
+            onChange={(e) => onChange('inputCount', parseInt(e.target.value, 10) || 1)}
+            className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+        </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/SetSettings.tsx
+++ b/src/components/SetSettings.tsx
@@ -1,4 +1,6 @@
 
+import { FiInfo } from 'react-icons/fi';
+
 interface SetSettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -22,42 +24,52 @@ export default function SetSettings({ data, onChange }: SetSettingsProps) {
   };
 
   return (
-    <div className="space-y-2 text-left">
-      {mappings.map((map, idx) => (
-        <div key={idx} className="flex items-center gap-2">
+    <div className="space-y-4 text-left">
+      <fieldset className="space-y-2">
+        <legend className="font-medium">Mappings</legend>
+        {mappings.map((map, idx) => (
+          <div key={idx} className="flex items-center gap-2">
+            <input
+              type="text"
+              value={map.field}
+              onChange={(e) => handleMappingChange(idx, 'field', e.target.value)}
+              placeholder="Field"
+              className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+            />
+            <input
+              type="text"
+              value={map.value}
+              onChange={(e) => handleMappingChange(idx, 'value', e.target.value)}
+              placeholder="Value"
+              className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+            />
+            <button
+              onClick={() => removeMapping(idx)}
+              className="px-2 py-1 text-xs bg-red-500 text-white rounded"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button onClick={addMapping} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">
+          Add Field
+        </button>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="font-medium">Options</legend>
+        <div className="flex items-center gap-2">
           <input
-            type="text"
-            value={map.field}
-            onChange={(e) => handleMappingChange(idx, 'field', e.target.value)}
-            placeholder="Field"
-            className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+            type="checkbox"
+            checked={Boolean(data.keepOnlySetFields)}
+            onChange={(e) => onChange('keepOnlySetFields', e.target.checked)}
           />
-          <input
-            type="text"
-            value={map.value}
-            onChange={(e) => handleMappingChange(idx, 'value', e.target.value)}
-            placeholder="Value"
-            className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
-          />
-          <button
-            onClick={() => removeMapping(idx)}
-            className="px-2 py-1 text-xs bg-red-500 text-white rounded"
-          >
-            Remove
-          </button>
+          <span className="text-sm">
+            Keep Only Set Fields
+            <FiInfo className="inline-block ml-1" title="Remove fields not explicitly mapped" />
+          </span>
         </div>
-      ))}
-      <button onClick={addMapping} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">
-        Add Field
-      </button>
-      <div className="flex items-center gap-2 mt-2">
-        <input
-          type="checkbox"
-          checked={Boolean(data.keepOnlySetFields)}
-          onChange={(e) => onChange('keepOnlySetFields', e.target.checked)}
-        />
-        <span className="text-sm">Keep Only Set Fields</span>
-      </div>
+      </fieldset>
     </div>
   );
 }

--- a/src/components/WebhookSettings.tsx
+++ b/src/components/WebhookSettings.tsx
@@ -1,3 +1,5 @@
+import { FiInfo } from 'react-icons/fi';
+
 interface WebhookSettingsProps {
   data: Record<string, unknown>;
   onChange: (field: string, value: unknown) => void;
@@ -5,82 +7,118 @@ interface WebhookSettingsProps {
 
 export default function WebhookSettings({ data, onChange }: WebhookSettingsProps) {
   return (
-    <div className="space-y-3 text-left">
-      <div>
-        <label className="block text-sm mb-1">Test URL</label>
-        <input
-          className="w-full border px-2 py-1"
-          value={data.testUrl as string || ''}
-          readOnly
-        />
-      </div>
-      <div>
-        <label className="block text-sm mb-1">Production URL</label>
-        <input
-          className="w-full border px-2 py-1"
-          value={data.prodUrl as string || ''}
-          onChange={(e) => onChange('prodUrl', e.target.value)}
-        />
-      </div>
-      <div>
-        <label className="block text-sm mb-1">HTTP Method</label>
-        <select
-          className="w-full border px-2 py-1"
-          value={(data.method as string) || 'GET'}
-          onChange={(e) => onChange('method', e.target.value)}
-        >
-          {['GET', 'POST', 'PUT', 'DELETE'].map((m) => (
-            <option key={m} value={m}>{m}</option>
-          ))}
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm mb-1">Path</label>
-        <input
-          className="w-full border px-2 py-1"
-          value={data.path as string || ''}
-          onChange={(e) => onChange('path', e.target.value)}
-        />
-      </div>
-      <div>
-        <label className="block text-sm mb-1">Authentication</label>
-        <select
-          className="w-full border px-2 py-1"
-          value={(data.auth as string) || 'None'}
-          onChange={(e) => onChange('auth', e.target.value)}
-        >
-          <option value="None">None</option>
-          <option value="Basic">Basic</option>
-          <option value="Bearer">Bearer</option>
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm mb-1">Respond</label>
-        <select
-          className="w-full border px-2 py-1"
-          value={(data.respond as string) || 'Immediately'}
-          onChange={(e) => onChange('respond', e.target.value)}
-        >
-          <option value="Immediately">Immediately</option>
-          <option value="After Workflow">After Workflow</option>
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm mb-1">Notes</label>
-        <textarea
-          className="w-full border px-2 py-1"
-          value={data.notes as string || ''}
-          onChange={(e) => onChange('notes', e.target.value)}
-        />
-      </div>
-      <div className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={Boolean(data.displayNote)}
-          onChange={(e) => onChange('displayNote', e.target.checked)}
-        />
-        <span className="text-sm">Display Note in Flow</span>
-      </div>
+    <div className="space-y-4 text-left">
+      <fieldset className="space-y-3">
+        <legend className="font-medium">Request</legend>
+        <div>
+          <label className="block text-sm mb-1">
+            Test URL
+            <FiInfo className="inline-block ml-1" title="Generated test webhook URL" />
+          </label>
+          <input
+            className="w-full border px-2 py-1"
+            value={data.testUrl as string || ''}
+            readOnly
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">
+            Production URL
+            <FiInfo className="inline-block ml-1" title="URL for production use" />
+          </label>
+          <input
+            className="w-full border px-2 py-1"
+            value={data.prodUrl as string || ''}
+            onChange={(e) => onChange('prodUrl', e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">
+            HTTP Method
+            <FiInfo className="inline-block ml-1" title="HTTP method for webhook" />
+          </label>
+          <select
+            className="w-full border px-2 py-1"
+            value={(data.method as string) || 'GET'}
+            onChange={(e) => onChange('method', e.target.value)}
+          >
+            {['GET', 'POST', 'PUT', 'DELETE'].map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">
+            Path
+            <FiInfo className="inline-block ml-1" title="Relative request path" />
+          </label>
+          <input
+            className="w-full border px-2 py-1"
+            value={data.path as string || ''}
+            onChange={(e) => onChange('path', e.target.value)}
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-3">
+        <legend className="font-medium">Authentication</legend>
+        <div>
+          <label className="block text-sm mb-1">
+            Authentication
+            <FiInfo className="inline-block ml-1" title="Webhook authentication type" />
+          </label>
+          <select
+            className="w-full border px-2 py-1"
+            value={(data.auth as string) || 'None'}
+            onChange={(e) => onChange('auth', e.target.value)}
+          >
+            <option value="None">None</option>
+            <option value="Basic">Basic</option>
+            <option value="Bearer">Bearer</option>
+          </select>
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-3">
+        <legend className="font-medium">Response</legend>
+        <div>
+          <label className="block text-sm mb-1">
+            Respond
+            <FiInfo className="inline-block ml-1" title="When to respond to caller" />
+          </label>
+          <select
+            className="w-full border px-2 py-1"
+            value={(data.respond as string) || 'Immediately'}
+            onChange={(e) => onChange('respond', e.target.value)}
+          >
+            <option value="Immediately">Immediately</option>
+            <option value="After Workflow">After Workflow</option>
+          </select>
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-3">
+        <legend className="font-medium">Notes</legend>
+        <div>
+          <label className="block text-sm mb-1">
+            Notes
+            <FiInfo className="inline-block ml-1" title="Internal note for this webhook" />
+          </label>
+          <textarea
+            className="w-full border px-2 py-1"
+            value={data.notes as string || ''}
+            onChange={(e) => onChange('notes', e.target.value)}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={Boolean(data.displayNote)}
+            onChange={(e) => onChange('displayNote', e.target.checked)}
+          />
+          <span className="text-sm">Display Note in Flow</span>
+        </div>
+      </fieldset>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- group related settings in fieldsets with legends
- add FiInfo tooltip icons beside setting labels for context

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853b9f3fbd083209b61f1a12d971661