### PR TITLE
Add Test Node button

### DIFF
--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -1,0 +1,11 @@
+interface JsonViewerProps {
+  data: unknown;
+}
+
+export default function JsonViewer({ data }: JsonViewerProps) {
+  return (
+    <pre className="bg-gray-100 p-2 rounded text-left text-xs overflow-auto max-h-60 w-full">
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple JSON viewer component
- support testing nodes via fetch and show results
- mock `fetch('https://jsonplaceholder.typicode.com/posts')` to avoid real network

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6853cbb3b1608320ad2dc9eb4a805124