### PR TITLE
Add variable picker across node settings

### DIFF
--- a/src/components/AirtableSettings.tsx
+++ b/src/components/AirtableSettings.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
+import VariablePicker from './VariablePicker';
 
 interface AirtableSettingsProps {
   data: Record<string, unknown>;
@@ -106,6 +107,11 @@ export default function AirtableSettings({ data, onChange, onValidationChange }:
             onChange={(e) => onChange('fields', e.target.value)}
             className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
           />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('fields', ((data.fields as string) || '') + v)
+            }
+          />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-600 mb-2">
@@ -117,6 +123,11 @@ export default function AirtableSettings({ data, onChange, onValidationChange }:
             value={(data.filter as string) || ''}
             onChange={(e) => onChange('filter', e.target.value)}
             className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('filter', ((data.filter as string) || '') + v)
+            }
           />
         </div>
       </fieldset>

--- a/src/components/CodeSettings.tsx
+++ b/src/components/CodeSettings.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
+import VariablePicker from './VariablePicker';
 
 interface CodeSettingsProps {
   data: Record<string, unknown>;
@@ -65,6 +66,9 @@ export default function CodeSettings({ data, onChange, onValidationChange }: Cod
             value={(data.code as string) || ''}
             onChange={(e) => onChange('code', e.target.value)}
             className={`w-full h-32 px-3 py-2 border rounded-md font-mono text-sm ${codeError ? 'border-red-500' : 'border-gray-600'}`}
+          />
+          <VariablePicker
+            onSelect={(v) => onChange('code', ((data.code as string) || '') + v)}
           />
           {codeError && (
             <p className="text-red-500 text-xs mt-1">{codeError}</p>

--- a/src/components/EmailSettings.tsx
+++ b/src/components/EmailSettings.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
+import VariablePicker from './VariablePicker';
 
 interface EmailSettingsProps {
   data: Record<string, unknown>;
@@ -137,6 +138,11 @@ export default function EmailSettings({ data, onChange, onValidationChange }: Em
             onChange={(e) => onChange('subject', e.target.value)}
             className="w-full px-3 py-2 border border-gray-600 rounded-md"
           />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('subject', ((data.subject as string) || '') + v)
+            }
+          />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-600 mb-2">
@@ -147,6 +153,11 @@ export default function EmailSettings({ data, onChange, onValidationChange }: Em
             value={(data.body as string) || ''}
             onChange={(e) => onChange('body', e.target.value)}
             className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md"
+          />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('body', ((data.body as string) || '') + v)
+            }
           />
         </div>
         <div>
@@ -159,6 +170,11 @@ export default function EmailSettings({ data, onChange, onValidationChange }: Em
             value={(data.attachments as string) || ''}
             onChange={(e) => onChange('attachments', e.target.value)}
             className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('attachments', ((data.attachments as string) || '') + v)
+            }
           />
         </div>
       </fieldset>

--- a/src/components/HttpRequestSettings.tsx
+++ b/src/components/HttpRequestSettings.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent } from 'react';
 import { FiInfo } from 'react-icons/fi';
+import VariablePicker from './VariablePicker';
 
 interface HttpRequestSettingsProps {
   data: Record<string, unknown>;
@@ -51,6 +52,9 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
             placeholder="https://api.example.com/endpoint"
             className="w-full px-3 py-2  border border-gray-600 rounded-md"
           />
+          <VariablePicker
+            onSelect={(v) => onChange('url', ((data.url as string) || '') + v)}
+          />
         </div>
       </fieldset>
 
@@ -67,6 +71,11 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
             placeholder='{"Content-Type": "application/json"}'
             className="w-full h-24 px-3 py-2  border border-gray-600 rounded-md  font-mono text-sm"
           />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('headers', ((data.headers as string) || '') + v)
+            }
+          />
         </div>
       </fieldset>
 
@@ -82,6 +91,11 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
             onChange={(e) => onChange('body', e.target.value)}
             placeholder="{name: 'John Doe'}"
             className="w-full h-32 px-3 py-2  border border-gray-600 rounded-md font-mono text-sm"
+          />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('body', ((data.body as string) || '') + v)
+            }
           />
         </div>
         <div>

--- a/src/components/IfSettings.tsx
+++ b/src/components/IfSettings.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
+import VariablePicker from './VariablePicker';
 
 interface IfSettingsProps {
   data: Record<string, unknown>;
@@ -78,6 +79,20 @@ export default function IfSettings({ data, onChange, onValidationChange }: IfSet
             >
               Remove
             </button>
+            <div className="flex w-full gap-2 mt-1">
+              <VariablePicker
+                label="Left"
+                onSelect={(v) =>
+                  handleConditionChange(idx, 'left', c.left + v)
+                }
+              />
+              <VariablePicker
+                label="Right"
+                onSelect={(v) =>
+                  handleConditionChange(idx, 'right', c.right + v)
+                }
+              />
+            </div>
           </div>
         ))}
         <button onClick={addCondition} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">

--- a/src/components/MergeSettings.tsx
+++ b/src/components/MergeSettings.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect } from 'react';
 import { FiInfo } from 'react-icons/fi';
+import VariablePicker from './VariablePicker';
 
 interface MergeSettingsProps {
   data: Record<string, unknown>;
@@ -43,6 +44,11 @@ export default function MergeSettings({ data, onChange, onValidationChange }: Me
             onChange={(e) => onChange('mergeFields', e.target.value)}
             placeholder="Comma separated fields"
             className="w-full px-3 py-2 border border-gray-600 rounded-md"
+          />
+          <VariablePicker
+            onSelect={(v) =>
+              onChange('mergeFields', ((data.mergeFields as string) || '') + v)
+            }
           />
         </div>
       </fieldset>

--- a/src/components/SetSettings.tsx
+++ b/src/components/SetSettings.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
+import VariablePicker from './VariablePicker';
 
 interface SetSettingsProps {
   data: Record<string, unknown>;
@@ -54,6 +55,11 @@ export default function SetSettings({ data, onChange, onValidationChange }: SetS
               onChange={(e) => handleMappingChange(idx, 'value', e.target.value)}
               placeholder="Value"
               className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
+            />
+            <VariablePicker
+              onSelect={(v) =>
+                handleMappingChange(idx, 'value', map.value + v)
+              }
             />
             <button
               onClick={() => removeMapping(idx)}

--- a/src/components/VariablePicker.tsx
+++ b/src/components/VariablePicker.tsx
@@ -1,0 +1,48 @@
+import { useWorkflowStore } from '../store/workflowStore';
+
+interface VariablePickerProps {
+  /** Called with the selected variable expression */
+  onSelect: (variableExpression: string) => void;
+  /** Optional label for the select element */
+  label?: string;
+}
+
+export default function VariablePicker({ onSelect, label }: VariablePickerProps) {
+  const variables = useWorkflowStore((state) => state.variables);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    if (val) {
+      onSelect(`{{${val}}}`);
+      e.target.selectedIndex = 0;
+    }
+  };
+
+  if (!variables.length) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2">
+      {label && (
+        <label className="block text-sm font-medium text-gray-600 mb-1">
+          {label}
+        </label>
+      )}
+      <select
+        onChange={handleChange}
+        className="w-full px-3 py-2 border border-gray-600 rounded-md"
+        defaultValue=""
+      >
+        <option value="" disabled>
+          Insert variable...
+        </option>
+        {variables.map((v) => (
+          <option key={v} value={v}>
+            {v}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -4,6 +4,7 @@ import type { WorkflowStore } from '../types/workflow';
 const initialState = {
   nodes: [],
   edges: [],
+  variables: [],
   selectedNode: null,
   undoStack: [],
   redoStack: [],
@@ -87,4 +88,12 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   setPendingConnection: (connection) => set({ pendingConnection: connection }),
   setNodeToAdd: (type) => set({ nodeToAdd: type }),
   setDraggingNodeId: (id) => set({ draggingNodeId: id }),
+  addVariable: (name) =>
+    set((state) =>
+      state.variables.includes(name)
+        ? {}
+        : { variables: [...state.variables, name] }
+    ),
+  removeVariable: (name) =>
+    set((state) => ({ variables: state.variables.filter((v) => v !== name) })),
 }));

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -43,6 +43,8 @@ export interface PendingConnection {
 export interface WorkflowState {
   nodes: WorkflowNode[];
   edges: WorkflowEdge[];
+  /** List of variables available for expression pickers */
+  variables: string[];
   selectedNode: string | null;
   undoStack: Array<{ nodes: WorkflowNode[]; edges: WorkflowEdge[] }>;
   redoStack: Array<{ nodes: WorkflowNode[]; edges: WorkflowEdge[] }>;
@@ -69,4 +71,6 @@ export interface WorkflowStore extends WorkflowState {
   setPendingConnection: (connection: PendingConnection | null) => void;
   setNodeToAdd: (type: NodeType | null) => void;
   setDraggingNodeId: (id: string | null) => void;
+  addVariable: (name: string) => void;
+  removeVariable: (name: string) => void;
 }


### PR DESCRIPTION
## Summary
- add `VariablePicker` usage for URL and headers in `HttpRequestSettings`
- allow variable insertion for Airtable fields and filters
- enable variable picker for code blocks
- insert variables in email settings fields
- support variable selection in conditional and mapping settings
- extend merge fields with variable picker

## Testing
- `yarn lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6853dbbe20048320a6f922dff1354080