### PR TITLE
Improve MergeNode data typing

### DIFF
--- a/src/components/nodes/MergeNode.tsx
+++ b/src/components/nodes/MergeNode.tsx
@@ -5,7 +5,11 @@ import type { WorkflowNodeData } from '../../types/workflow';
 import { FiGitMerge, FiPlus, FiTrash2 } from 'react-icons/fi';
 import { useWorkflowStore } from '../../store/workflowStore';
 
-interface MergeNodeProps extends NodeProps<WorkflowNodeData> {
+interface MergeNodeData extends WorkflowNodeData {
+  inputCount?: number;
+}
+
+interface MergeNodeProps extends NodeProps<MergeNodeData> {
   darkMode?: boolean;
 }
 
@@ -39,7 +43,7 @@ function MergeNode({ id, data, darkMode = false }: MergeNodeProps) {
     }
   }, [darkMode]);
 
-  const inputCount = (data as { inputCount?: number }).inputCount ?? 2;
+  const inputCount = data.inputCount ?? 2;
   const step = 100 / (inputCount + 1);
   const [hovered, setHovered] = React.useState(false);
 


### PR DESCRIPTION
## Summary
- introduce `MergeNodeData` interface to define `inputCount`
- use `MergeNodeData` in `MergeNode` component

## Testing
- `yarn lint` *(fails: Cannot find package '@eslint/js')*
- `yarn build` *(fails: TS7006 Parameter implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_6853e5c23058832090d184144ee6f04a