### PR TITLE
Make initializeNodeId generic

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 import { useThemeStore } from '../store/themeStore';
 import { initializeNodeId } from '../utils/getNodeId';
+import type { WorkflowNode } from '../types/workflow';
 import { setupEdges } from '../utils/setupEdges';
 import { FiSun, FiMoon } from 'react-icons/fi';
 
@@ -71,7 +72,7 @@ export function Toolbar() {
               nodes: workflow.nodes,
               edges: edgesWithHandlers,
             });
-            initializeNodeId(workflow.nodes || []);
+            initializeNodeId((workflow.nodes as WorkflowNode[]) || []);
           } catch {
             alert('Invalid workflow file');
           }

--- a/src/utils/getNodeId.ts
+++ b/src/utils/getNodeId.ts
@@ -2,7 +2,7 @@ let id = 0;
 
 export const getNodeId = () => `node_${id++}`;
 
-export const initializeNodeId = (nodes: { id: string }[]) => {
+export const initializeNodeId = <T extends { id: string }>(nodes: T[]) => {
   let maxId = -1;
   for (const node of nodes) {
     const match = node.id.match(/^node_(\d+)$/);


### PR DESCRIPTION
## Summary
- update `initializeNodeId` to accept a generic collection
- cast workflow nodes to `WorkflowNode[]` before initializing IDs

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6853eedf0d048320a35fa055f2a48660