### PR TITLE
Add expression evaluation utility

### DIFF
--- a/src/utils/evaluateExpression.ts
+++ b/src/utils/evaluateExpression.ts
@@ -1,0 +1,21 @@
+export function evaluateExpression(
+  expr: string,
+  context: Record<string, unknown>,
+): unknown {
+  const fullExpr = expr.match(/^\s*{{([\s\S]*?)}}\s*$/);
+  if (fullExpr) {
+    return runExpression(fullExpr[1], context);
+  }
+
+  const regex = /{{\s*([\s\S]*?)\s*}}/g;
+  return expr.replace(regex, (_, code: string) => {
+    const result = runExpression(code, context);
+    return result !== undefined && result !== null ? String(result) : '';
+  });
+}
+
+function runExpression(code: string, context: Record<string, unknown>): unknown {
+  const fn = new Function('$json', '$input', '$', `return ${code}`);
+  return fn(context.$json, context.$input, context);
+}
+export default evaluateExpression;


### PR DESCRIPTION
## Summary
- add `evaluateExpression` helper that runs `{{ }}` template expressions

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_685499580b5c8320b42105e43e2d1ee6