### PR TITLE
Extend workflow store with node IO tracking

### DIFF
--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -12,6 +12,8 @@ const initialState = {
   nodes: [],
   edges: [],
   variables: [],
+  inputByNode: {},
+  outputByNode: {},
   selectedNode: null,
   undoStack: [],
   redoStack: [],
@@ -105,5 +107,15 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   removeVariable: (name: string) =>
     set((state: WorkflowState) => ({
       variables: state.variables.filter((v: string) => v !== name),
+    })),
+
+  setInputForNode: (nodeId: string, items: unknown[]) =>
+    set((state: WorkflowState) => ({
+      inputByNode: { ...state.inputByNode, [nodeId]: items },
+    })),
+
+  setOutputForNode: (nodeId: string, items: unknown[]) =>
+    set((state: WorkflowState) => ({
+      outputByNode: { ...state.outputByNode, [nodeId]: items },
     })),
 }));

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -45,6 +45,10 @@ export interface WorkflowState {
   edges: WorkflowEdge[];
   /** List of variables available for expression pickers */
   variables: string[];
+  /** Map of nodeId -> array of input items */
+  inputByNode: Record<string, unknown[]>;
+  /** Map of nodeId -> array of output items */
+  outputByNode: Record<string, unknown[]>;
   selectedNode: string | null;
   undoStack: Array<{ nodes: WorkflowNode[]; edges: WorkflowEdge[] }>;
   redoStack: Array<{ nodes: WorkflowNode[]; edges: WorkflowEdge[] }>;
@@ -73,4 +77,6 @@ export interface WorkflowStore extends WorkflowState {
   setDraggingNodeId: (id: string | null) => void;
   addVariable: (name: string) => void;
   removeVariable: (name: string) => void;
+  setInputForNode: (nodeId: string, items: unknown[]) => void;
+  setOutputForNode: (nodeId: string, items: unknown[]) => void;
 }


### PR DESCRIPTION
## Summary
- add `inputByNode` and `outputByNode` maps to the workflow state
- expose actions `setInputForNode` and `setOutputForNode`

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68549ef6058c83208c86e5983b0a2a43