### PR TITLE
Add expression toggle for settings inputs

### DIFF
--- a/src/components/AirtableSettings.tsx
+++ b/src/components/AirtableSettings.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
-import VariablePicker from './VariablePicker';
+import ExpressionInput from './ExpressionInput';
 
 interface AirtableSettingsProps {
   data: Record<string, unknown>;
@@ -102,15 +102,10 @@ export default function AirtableSettings({ data, onChange, onValidationChange }:
             Fields (JSON)
             <FiInfo className="inline-block ml-1" title="Fields payload" />
           </label>
-          <textarea
+          <ExpressionInput
             value={(data.fields as string) || ''}
-            onChange={(e) => onChange('fields', e.target.value)}
-            className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md font-mono text-sm"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('fields', ((data.fields as string) || '') + v)
-            }
+            onChange={(v) => onChange('fields', v)}
+            multiline
           />
         </div>
         <div>
@@ -118,16 +113,9 @@ export default function AirtableSettings({ data, onChange, onValidationChange }:
             Filter Formula
             <FiInfo className="inline-block ml-1" title="Airtable filter formula" />
           </label>
-          <input
-            type="text"
+          <ExpressionInput
             value={(data.filter as string) || ''}
-            onChange={(e) => onChange('filter', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-600 rounded-md"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('filter', ((data.filter as string) || '') + v)
-            }
+            onChange={(v) => onChange('filter', v)}
           />
         </div>
       </fieldset>

--- a/src/components/CodeSettings.tsx
+++ b/src/components/CodeSettings.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
-import VariablePicker from './VariablePicker';
+import ExpressionInput from './ExpressionInput';
 
 interface CodeSettingsProps {
   data: Record<string, unknown>;
@@ -62,13 +62,10 @@ export default function CodeSettings({ data, onChange, onValidationChange }: Cod
             Code
             <FiInfo className="inline-block ml-1" title="Script content" />
           </label>
-          <textarea
+          <ExpressionInput
             value={(data.code as string) || ''}
-            onChange={(e) => onChange('code', e.target.value)}
-            className={`w-full h-32 px-3 py-2 border rounded-md font-mono text-sm ${codeError ? 'border-red-500' : 'border-gray-600'}`}
-          />
-          <VariablePicker
-            onSelect={(v) => onChange('code', ((data.code as string) || '') + v)}
+            onChange={(v) => onChange('code', v)}
+            multiline
           />
           {codeError && (
             <p className="text-red-500 text-xs mt-1">{codeError}</p>

--- a/src/components/EmailSettings.tsx
+++ b/src/components/EmailSettings.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
-import VariablePicker from './VariablePicker';
+import ExpressionInput from './ExpressionInput';
 
 interface EmailSettingsProps {
   data: Record<string, unknown>;
@@ -132,16 +132,9 @@ export default function EmailSettings({ data, onChange, onValidationChange }: Em
             Subject
             <FiInfo className="inline-block ml-1" title="Email subject" />
           </label>
-          <input
-            type="text"
+          <ExpressionInput
             value={(data.subject as string) || ''}
-            onChange={(e) => onChange('subject', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-600 rounded-md"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('subject', ((data.subject as string) || '') + v)
-            }
+            onChange={(v) => onChange('subject', v)}
           />
         </div>
         <div>
@@ -149,15 +142,10 @@ export default function EmailSettings({ data, onChange, onValidationChange }: Em
             Body
             <FiInfo className="inline-block ml-1" title="Email body" />
           </label>
-          <textarea
+          <ExpressionInput
             value={(data.body as string) || ''}
-            onChange={(e) => onChange('body', e.target.value)}
-            className="w-full h-24 px-3 py-2 border border-gray-600 rounded-md"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('body', ((data.body as string) || '') + v)
-            }
+            onChange={(v) => onChange('body', v)}
+            multiline
           />
         </div>
         <div>
@@ -165,16 +153,9 @@ export default function EmailSettings({ data, onChange, onValidationChange }: Em
             Attachments (comma separated URLs)
             <FiInfo className="inline-block ml-1" title="Attachment links" />
           </label>
-          <input
-            type="text"
+          <ExpressionInput
             value={(data.attachments as string) || ''}
-            onChange={(e) => onChange('attachments', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-600 rounded-md"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('attachments', ((data.attachments as string) || '') + v)
-            }
+            onChange={(v) => onChange('attachments', v)}
           />
         </div>
       </fieldset>

--- a/src/components/ExpressionInput.tsx
+++ b/src/components/ExpressionInput.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import type { ChangeEvent } from 'react';
+import VariablePicker from './VariablePicker';
+import evaluateExpression from '../utils/evaluateExpression';
+
+interface ExpressionInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  multiline?: boolean;
+}
+
+export default function ExpressionInput({
+  value,
+  onChange,
+  placeholder,
+  multiline,
+}: ExpressionInputProps) {
+  const [exprMode, setExprMode] = useState(false);
+  const [error, setError] = useState(false);
+
+  const toggle = () => setExprMode((v) => !v);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    onChange(val);
+    if (exprMode) {
+      try {
+        evaluateExpression(val, {});
+        setError(false);
+      } catch {
+        setError(true);
+      }
+    }
+  };
+
+  const handleInsert = (v: string) => {
+    const newVal = value + v;
+    onChange(newVal);
+    if (exprMode) {
+      try {
+        evaluateExpression(newVal, {});
+        setError(false);
+      } catch {
+        setError(true);
+      }
+    }
+  };
+
+  const inputClasses = `w-full px-3 py-2 border rounded-md ${error ? 'border-red-500' : 'border-gray-600'}`;
+  const textareaClasses = `w-full h-24 px-3 py-2 border rounded-md font-mono text-sm ${error ? 'border-red-500' : 'border-gray-600'}`;
+
+  return (
+    <div>
+      <div className="relative">
+        {exprMode && multiline ? (
+          <textarea
+            value={value}
+            onChange={handleChange}
+            placeholder={placeholder}
+            className={textareaClasses}
+          />
+        ) : exprMode ? (
+          <textarea
+            value={value}
+            onChange={handleChange}
+            placeholder={placeholder}
+            className={textareaClasses}
+          />
+        ) : (
+          <input
+            type="text"
+            value={value}
+            onChange={handleChange}
+            placeholder={placeholder}
+            className={inputClasses}
+          />
+        )}
+        <button
+          type="button"
+          onClick={toggle}
+          title="Toggle expression"
+          className="absolute right-1 top-1 px-1 text-xs border border-gray-400 rounded"
+        >
+          {'</>'}
+        </button>
+      </div>
+      {exprMode && <VariablePicker onSelect={handleInsert} />}
+    </div>
+  );
+}

--- a/src/components/HttpRequestSettings.tsx
+++ b/src/components/HttpRequestSettings.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent } from 'react';
 import { FiInfo } from 'react-icons/fi';
-import VariablePicker from './VariablePicker';
+import ExpressionInput from './ExpressionInput';
 
 interface HttpRequestSettingsProps {
   data: Record<string, unknown>;
@@ -45,15 +45,10 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
             URL
             <FiInfo className="inline-block ml-1" title="Request endpoint" />
           </label>
-          <input
-            type="text"
+          <ExpressionInput
             value={(data.url as string) || ''}
-            onChange={(e) => onChange('url', e.target.value)}
+            onChange={(v) => onChange('url', v)}
             placeholder="https://api.example.com/endpoint"
-            className="w-full px-3 py-2  border border-gray-600 rounded-md"
-          />
-          <VariablePicker
-            onSelect={(v) => onChange('url', ((data.url as string) || '') + v)}
           />
         </div>
       </fieldset>
@@ -65,16 +60,11 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
             Headers (JSON)
             <FiInfo className="inline-block ml-1" title="Additional request headers" />
           </label>
-          <textarea
+          <ExpressionInput
             value={(data.headers as string) || ''}
-            onChange={(e) => onChange('headers', e.target.value)}
+            onChange={(v) => onChange('headers', v)}
             placeholder='{"Content-Type": "application/json"}'
-            className="w-full h-24 px-3 py-2  border border-gray-600 rounded-md  font-mono text-sm"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('headers', ((data.headers as string) || '') + v)
-            }
+            multiline
           />
         </div>
       </fieldset>
@@ -86,16 +76,11 @@ export default function HttpRequestSettings({ data, onChange }: HttpRequestSetti
             Body
             <FiInfo className="inline-block ml-1" title="Request payload" />
           </label>
-          <textarea
+          <ExpressionInput
             value={(data.body as string) || ''}
-            onChange={(e) => onChange('body', e.target.value)}
+            onChange={(v) => onChange('body', v)}
             placeholder="{name: 'John Doe'}"
-            className="w-full h-32 px-3 py-2  border border-gray-600 rounded-md font-mono text-sm"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('body', ((data.body as string) || '') + v)
-            }
+            multiline
           />
         </div>
         <div>

--- a/src/components/IfSettings.tsx
+++ b/src/components/IfSettings.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
-import VariablePicker from './VariablePicker';
+import ExpressionInput from './ExpressionInput';
 
 interface IfSettingsProps {
   data: Record<string, unknown>;
@@ -42,12 +42,9 @@ export default function IfSettings({ data, onChange, onValidationChange }: IfSet
         <legend className="font-medium">Conditions</legend>
         {conditions.map((c, idx) => (
           <div key={idx} className="flex flex-wrap items-center gap-2 min-w-0">
-            <input
-              type="text"
+            <ExpressionInput
               value={c.left}
-              onChange={(e) => handleConditionChange(idx, 'left', e.target.value)}
-              placeholder="Field"
-              className="flex-1 min-w-0 px-2 py-1 border border-gray-600 rounded-md"
+              onChange={(v) => handleConditionChange(idx, 'left', v)}
             />
             <select
               value={c.op}
@@ -66,12 +63,9 @@ export default function IfSettings({ data, onChange, onValidationChange }: IfSet
               <option value="starts_with">starts with</option>
               <option value="ends_with">ends with</option>
             </select>
-            <input
-              type="text"
+            <ExpressionInput
               value={c.right}
-              onChange={(e) => handleConditionChange(idx, 'right', e.target.value)}
-              placeholder="Value"
-              className="flex-1 min-w-0 px-2 py-1 border border-gray-600 rounded-md"
+              onChange={(v) => handleConditionChange(idx, 'right', v)}
             />
             <button
               onClick={() => removeCondition(idx)}
@@ -79,20 +73,6 @@ export default function IfSettings({ data, onChange, onValidationChange }: IfSet
             >
               Remove
             </button>
-            <div className="flex w-full gap-2 mt-1">
-              <VariablePicker
-                label="Left"
-                onSelect={(v) =>
-                  handleConditionChange(idx, 'left', c.left + v)
-                }
-              />
-              <VariablePicker
-                label="Right"
-                onSelect={(v) =>
-                  handleConditionChange(idx, 'right', c.right + v)
-                }
-              />
-            </div>
           </div>
         ))}
         <button onClick={addCondition} className="px-2 py-1 text-xs bg-blue-500 text-white rounded">

--- a/src/components/MergeSettings.tsx
+++ b/src/components/MergeSettings.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect } from 'react';
 import { FiInfo } from 'react-icons/fi';
-import VariablePicker from './VariablePicker';
+import ExpressionInput from './ExpressionInput';
 
 interface MergeSettingsProps {
   data: Record<string, unknown>;
@@ -38,17 +38,10 @@ export default function MergeSettings({ data, onChange, onValidationChange }: Me
             Fields
             <FiInfo className="inline-block ml-1" title="Fields to merge" />
           </label>
-          <input
-            type="text"
+          <ExpressionInput
             value={(data.mergeFields as string) || ''}
-            onChange={(e) => onChange('mergeFields', e.target.value)}
+            onChange={(v) => onChange('mergeFields', v)}
             placeholder="Comma separated fields"
-            className="w-full px-3 py-2 border border-gray-600 rounded-md"
-          />
-          <VariablePicker
-            onSelect={(v) =>
-              onChange('mergeFields', ((data.mergeFields as string) || '') + v)
-            }
           />
         </div>
       </fieldset>

--- a/src/components/SetSettings.tsx
+++ b/src/components/SetSettings.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState } from 'react';
 import { FiInfo } from 'react-icons/fi';
-import VariablePicker from './VariablePicker';
+import ExpressionInput from './ExpressionInput';
 
 interface SetSettingsProps {
   data: Record<string, unknown>;
@@ -49,17 +49,9 @@ export default function SetSettings({ data, onChange, onValidationChange }: SetS
               placeholder="Field"
               className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
             />
-            <input
-              type="text"
+            <ExpressionInput
               value={map.value}
-              onChange={(e) => handleMappingChange(idx, 'value', e.target.value)}
-              placeholder="Value"
-              className="flex-1 px-2 py-1 border border-gray-600 rounded-md"
-            />
-            <VariablePicker
-              onSelect={(v) =>
-                handleMappingChange(idx, 'value', map.value + v)
-              }
+              onChange={(v) => handleMappingChange(idx, 'value', v)}
             />
             <button
               onClick={() => removeMapping(idx)}


### PR DESCRIPTION
## Summary
- add `ExpressionInput` component with plain/expression toggle
- use `ExpressionInput` in several settings components
- highlight invalid expressions in red borders

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6854a260108c83209c81bb8675b2347e