### PR TITLE
Add Dagre auto‑layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.5",
     "@tailwindcss/vite": "^4.1.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -29,7 +29,6 @@ export default function PropertiesPanel({
   const [isValid, setIsValid] = useState(true);
   // Error for the HTTP request URL field
   const [urlError, setUrlError] = useState('');
-  const [testOutput, setTestOutput] = useState<unknown>(null);
   const inputItems =
     useWorkflowStore((state) => state.inputByNode[node.id] || []);
   const outputItems =
@@ -413,12 +412,6 @@ export default function PropertiesPanel({
       </div>
       {nodeError && (
         <div className="w-full text-red-600 text-xs">Error: {nodeError}</div>
-      )}
-      {testOutput && (
-        <div className="w-full">
-          <div className="text-xs font-semibold">Test Output</div>
-          <JsonViewer data={testOutput} />
-        </div>
       )}
     </div>
   );

--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -35,6 +35,7 @@ import GlobalAddButton from "./GlobalAddButton";
 import ButtonEdge from "./edges/ButtonEdge";
 import { getNodeId } from "../utils/getNodeId";
 import { setupEdges } from "../utils/setupEdges";
+import getLayoutedElements from "../utils/getLayoutedElements";
 import { v4 as uuidv4 } from "uuid";
 import PropertiesPanel from "./PropertiesPanel";
 import HttpRequestNode from "./nodes/HttpRequestNode";
@@ -353,6 +354,17 @@ export function WorkflowEditor() {
     setStoreNodes(nodes as WorkflowNode[]);
   }, [nodes, setStoreNodes]);
 
+  const onLayout = useCallback(() => {
+    const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
+      nodes,
+      edges,
+      'LR',
+    );
+    setNodes(layoutedNodes);
+    setEdges(layoutedEdges);
+    setStoreNodes(layoutedNodes as WorkflowNode[]);
+  }, [nodes, edges, setNodes, setEdges, setStoreNodes]);
+
   const onDragOver = useCallback((event: React.DragEvent) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = "move";
@@ -543,6 +555,14 @@ export function WorkflowEditor() {
         <Controls />
         <MiniMap />
       </ReactFlow>
+      <div className="absolute top-2 right-2 z-10">
+        <button
+          onClick={onLayout}
+          className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded shadow text-sm"
+        >
+          Auto-Layout
+        </button>
+      </div>
       {nodes.length === 0 && (
         <button
           onClick={openSidebar}

--- a/src/utils/getLayoutedElements.ts
+++ b/src/utils/getLayoutedElements.ts
@@ -1,0 +1,45 @@
+import dagre from '@dagrejs/dagre';
+import type { Node, Edge } from 'reactflow';
+
+const dagreGraph = new dagre.graphlib.Graph();
+dagreGraph.setDefaultEdgeLabel(() => ({}));
+
+const nodeWidth = 172;
+const nodeHeight = 36;
+
+export function getLayoutedElements<N extends Node, E extends Edge>(
+  nodes: N[],
+  edges: E[],
+  direction: 'LR' | 'TB' = 'LR'
+): { nodes: N[]; edges: E[] } {
+  const isHorizontal = direction === 'LR';
+
+  dagreGraph.setGraph({ rankdir: direction });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  const layoutedNodes = nodes.map((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    return {
+      ...node,
+      targetPosition: isHorizontal ? 'left' : 'top',
+      sourcePosition: isHorizontal ? 'right' : 'bottom',
+      position: {
+        x: nodeWithPosition.x - nodeWidth / 2,
+        y: nodeWithPosition.y - nodeHeight / 2,
+      },
+    };
+  });
+
+  return { nodes: layoutedNodes, edges };
+}
+
+export default getLayoutedElements;

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,18 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
+"@dagrejs/dagre@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@dagrejs/dagre/-/dagre-1.1.5.tgz#af392e24723c479f00661af3f4e8ede5c6acce51"
+  integrity sha512-Ghgrh08s12DCL5SeiR6AoyE80mQELTWhJBRmXfFoqDiFkR458vPEdgTbbjA0T+9ETNxUblnD0QW55tfdvi5pjQ==
+  dependencies:
+    "@dagrejs/graphlib" "2.2.4"
+
+"@dagrejs/graphlib@2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@dagrejs/graphlib/-/graphlib-2.2.4.tgz#d77bfa9ff49e2307c0c6e6b8b26b5dd3c05816c4"
+  integrity sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==
+
 "@emnapi/core@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.3.tgz#9ac52d2d5aea958f67e52c40a065f51de59b77d6"


### PR DESCRIPTION
## Summary
- add `@dagrejs/dagre` dependency
- expose `getLayoutedElements` util for horizontal node layouts
- provide layout button in `WorkflowEditor`
- clean up unused code in `PropertiesPanel`

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6876c25f3814832082eef29440c7839a