### PR TITLE
Add Dagre auto-layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.5",
     "@tailwindcss/vite": "^4.1.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/WorkflowEditor.tsx
+++ b/src/components/WorkflowEditor.tsx
@@ -38,6 +38,7 @@ import { setupEdges } from "../utils/setupEdges";
 import { v4 as uuidv4 } from "uuid";
 import PropertiesPanel from "./PropertiesPanel";
 import HttpRequestNode from "./nodes/HttpRequestNode";
+import getLayoutedElements from "../utils/autoLayout";
 
 function getDefaultData(type: NodeType) {
   if (type === "webhook") {
@@ -358,6 +359,17 @@ export function WorkflowEditor() {
     event.dataTransfer.dropEffect = "move";
   }, []);
 
+  const onLayout = useCallback(() => {
+    const { nodes: newNodes, edges: newEdges } = getLayoutedElements(
+      nodes,
+      edges,
+      "LR",
+    );
+    setNodes(newNodes);
+    setEdges(newEdges as WorkflowEdge[]);
+    setStoreNodes(newNodes as WorkflowNode[]);
+  }, [nodes, edges, setNodes, setEdges, setStoreNodes]);
+
   const onConnectStart = useCallback(
     (_: React.MouseEvent | React.TouchEvent, params: OnConnectStartParams) => {
       connectStart.current = params;
@@ -543,6 +555,14 @@ export function WorkflowEditor() {
         <Controls />
         <MiniMap />
       </ReactFlow>
+      <div className="absolute top-2 right-2 z-10">
+        <button
+          onClick={onLayout}
+          className="px-2 py-1 bg-gray-200 rounded shadow"
+        >
+          Auto-Layout
+        </button>
+      </div>
       {nodes.length === 0 && (
         <button
           onClick={openSidebar}

--- a/src/utils/autoLayout.ts
+++ b/src/utils/autoLayout.ts
@@ -1,0 +1,44 @@
+import dagre from '@dagrejs/dagre';
+import type { Edge, Node } from 'reactflow';
+import { Position } from 'reactflow';
+
+const dagreGraph = new dagre.graphlib.Graph();
+dagreGraph.setDefaultEdgeLabel(() => ({}));
+
+const nodeWidth = 172;
+const nodeHeight = 36;
+
+export function getLayoutedElements(
+  nodes: Node[],
+  edges: Edge[],
+  direction: 'TB' | 'BT' | 'LR' | 'RL' = 'LR',
+): { nodes: Node[]; edges: Edge[] } {
+  dagreGraph.setGraph({ rankdir: direction });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  const layoutedNodes = nodes.map((node) => {
+    const dagreNode = dagreGraph.node(node.id);
+    return {
+      ...node,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+      position: {
+        x: dagreNode.x - nodeWidth / 2,
+        y: dagreNode.y - nodeHeight / 2,
+      },
+    };
+  });
+
+  return { nodes: layoutedNodes, edges };
+}
+
+export default getLayoutedElements;

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,18 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
+"@dagrejs/dagre@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@dagrejs/dagre/-/dagre-1.1.5.tgz#af392e24723c479f00661af3f4e8ede5c6acce51"
+  integrity sha512-Ghgrh08s12DCL5SeiR6AoyE80mQELTWhJBRmXfFoqDiFkR458vPEdgTbbjA0T+9ETNxUblnD0QW55tfdvi5pjQ==
+  dependencies:
+    "@dagrejs/graphlib" "2.2.4"
+
+"@dagrejs/graphlib@2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@dagrejs/graphlib/-/graphlib-2.2.4.tgz#d77bfa9ff49e2307c0c6e6b8b26b5dd3c05816c4"
+  integrity sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==
+
 "@emnapi/core@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.3.tgz#9ac52d2d5aea958f67e52c40a065f51de59b77d6"


### PR DESCRIPTION
## Summary
- add `@dagrejs/dagre` to project
- implement `getLayoutedElements` utility for Dagre based layout
- wire up auto layout button in `WorkflowEditor`

## Testing
- `yarn build` *(fails: PropertyPanel and runtime TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876c243af0c8320823193bae8c1e9e2